### PR TITLE
Fix GitHub Pages deployment and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,83 @@
-# Welcome to your Lovable project
+# Values Explorer
 
-## Project info
+An interactive philosophical tool for exploring Schwartz's Theory of Basic Human Values. Create value profiles, compare archetypes (fictional, historical, mythological characters), and generate AI-powered scenarios that reveal value tensions.
 
-**URL**: https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID
+**Live Demo**: https://brtrx.github.io/values-explorer/
 
-## How can I edit this code?
+## Features
 
-There are several ways of editing your application.
+- **Value Profile Editor**: Create and customize profiles using the 19 Schwartz PVQ-RR values
+- **Schwartz Circumplex Visualization**: Interactive circular display of value relationships
+- **Archetype Library**: 80+ pre-built character profiles (historical figures, fictional characters, mythological beings)
+- **Profile Comparison**: Compare multiple profiles to identify value alignments and tensions
+- **Carrier Analysis**: Explore 12 decision-space dimensions that force value trade-offs
+- **AI Scenario Generation**: Generate narratives that reveal how value tensions play out
 
-**Use Lovable**
+## Schwartz Values Framework
 
-Simply visit the [Lovable Project](https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID) and start prompting.
+The tool implements the refined 19-value model from the Portrait Values Questionnaire (PVQ-RR), organized into four higher-order values:
 
-Changes made via Lovable will be committed automatically to this repo.
+| Quadrant | Values |
+|----------|--------|
+| **Openness to Change** | Self-Direction (Thought/Action), Stimulation, Hedonism |
+| **Self-Enhancement** | Achievement, Power (Dominance/Resources), Face |
+| **Conservation** | Security (Personal/Societal), Tradition, Conformity (Rules/Interpersonal), Humility |
+| **Self-Transcendence** | Benevolence (Caring/Dependability), Universalism (Nature/Concern/Tolerance) |
 
-**Use your preferred IDE**
+## Tech Stack
 
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
+- **Frontend**: React 18, TypeScript, Vite 5, TailwindCSS
+- **UI Components**: shadcn/ui (Radix UI primitives)
+- **Backend**: Supabase (PostgreSQL, Edge Functions)
+- **State**: React Query, localStorage for drafts
+- **Routing**: React Router v6 (HashRouter for GitHub Pages)
 
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
+## Getting Started
 
-Follow these steps:
+```bash
+# Clone the repository
+git clone https://github.com/brtrx/values-explorer.git
+cd values-explorer
 
-```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
+# Install dependencies
+npm install
 
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Start development server
 npm run dev
 ```
 
-**Edit a file directly in GitHub**
+The app will be available at http://localhost:8080
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
+## Available Scripts
 
-**Use GitHub Codespaces**
+```bash
+npm run dev      # Start dev server
+npm run build    # Production build to /dist
+npm run lint     # ESLint validation
+npm run preview  # Preview production build
+```
 
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
+## Project Structure
 
-## What technologies are used for this project?
+```
+src/
+├── pages/           # Route components
+├── components/      # React components
+│   ├── ui/          # shadcn/ui primitives
+│   ├── ProfileEditor.tsx
+│   └── SchwartzCircle.tsx
+├── lib/             # Core business logic
+│   ├── schwartz-values.ts
+│   ├── archetypes.ts
+│   └── carriers.ts
+├── hooks/           # Custom React hooks
+└── integrations/    # Supabase client config
 
-This project is built with:
+supabase/
+├── migrations/      # Database schema
+└── functions/       # Edge functions for AI features
+```
 
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
+## License
 
-## How can I deploy this project?
-
-Simply open [Lovable](https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID) and click on Share -> Publish.
-
-## Can I connect a custom domain to my Lovable project?
-
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/features/custom-domain#custom-domain)
+This project is a philosophical experiment by Justin Tauber.

--- a/claude.md
+++ b/claude.md
@@ -14,16 +14,16 @@ An interactive philosophical tool for exploring Schwartz's Theory of Basic Human
 
 ```
 src/
-├── pages/           # Route components (Landing, Index, Compare, Carriers, ExploreScenarios)
+├── pages/           # Route components (Landing, Index, Compare, Carriers, ExploreScenarios, SharedProfile, NotFound)
 ├── components/      # React components
-│   ├── ui/          # shadcn/ui primitives (40+ components)
+│   ├── ui/          # shadcn/ui primitives (~48 components)
 │   ├── ProfileEditor.tsx      # Main editor with sidebar & visualization
 │   ├── SchwartzCircle.tsx     # Value circumplex visualization
 │   └── ...
 ├── lib/             # Core business logic
 │   ├── schwartz-values.ts     # 19 Schwartz value definitions
-│   ├── archetypes.ts          # 50+ character profiles (~1000 lines)
-│   ├── carriers.ts            # 12 decision-space carriers (~1100 lines)
+│   ├── archetypes.ts          # 80+ character profiles (~770 lines)
+│   ├── carriers.ts            # 12 decision-space carriers (~930 lines)
 │   ├── profile-storage.ts     # Supabase + localStorage integration
 │   └── validation.ts          # Zod schemas
 ├── hooks/           # Custom hooks (use-profile-draft, use-toast, use-mobile)
@@ -31,7 +31,7 @@ src/
 
 supabase/
 ├── migrations/      # Database schema (profiles table with JSONB scores)
-└── functions/       # Edge functions (compare-archetypes, generate-persona-scenario)
+└── functions/       # Edge functions (compare-archetypes, generate-persona-scenario, generate-archetype-image, generate-conflict-scenario)
 ```
 
 ## Commands
@@ -77,13 +77,13 @@ Map value-to-carrier relationships (-1 to +1) showing if a carrier satisfies or 
 
 ```sql
 profiles (
-  id UUID PRIMARY KEY,
-  name TEXT,
-  scores JSONB,        -- Record of 19 value scores
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL DEFAULT 'Untitled Profile',
+  scores JSONB NOT NULL DEFAULT '{}',  -- Record of 19 value scores
   description TEXT,
   system_prompt TEXT,
-  created_at TIMESTAMP,
-  updated_at TIMESTAMP
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
 )
 ```
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 export default defineConfig(({ mode }) => ({
   // Only use base path when explicitly building for GitHub Pages
-  base: process.env.GITHUB_ACTIONS ? '/trait-generator/' : '/',
+  base: process.env.GITHUB_ACTIONS ? '/values-explorer/' : '/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
- Fix base path in vite.config.ts from /trait-generator/ to /values-explorer/
- Update claude.md with accurate line counts, component counts, and missing pages/functions
- Rewrite README.md to describe the actual project instead of Lovable template