### PR TITLE
Add Supabase environment variables to GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -35,6 +35,9 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
       - name: List dist contents (debug)
         run: ls -la dist/
       - name: Setup Pages


### PR DESCRIPTION
Inject VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY from GitHub Secrets during the build step so Vite can embed them in the production bundle.