### PR TITLE
Replace Lovable API with OpenAI API in Edge Functions

### DIFF
--- a/supabase/functions/compare-archetypes/index.ts
+++ b/supabase/functions/compare-archetypes/index.ts
@@ -26,9 +26,9 @@ serve(async (req) => {
       );
     }
 
-    const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
-    if (!LOVABLE_API_KEY) {
-      throw new Error("LOVABLE_API_KEY is not configured");
+    const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
+    if (!OPENAI_API_KEY) {
+      throw new Error("OPENAI_API_KEY is not configured");
     }
 
     const archetypesSummary = archetypes.map(a => {
@@ -76,14 +76,14 @@ Write a compelling 3-4 paragraph comparison that:
 3. Notes any unexpected common ground
 4. Considers how they would view each other's choices`;
 
-    const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "google/gemini-2.5-flash",
+        model: "gpt-4o-mini",
         messages: [
           { role: "system", content: systemPrompt },
           { role: "user", content: userPrompt },

--- a/supabase/functions/generate-conflict-scenario/index.ts
+++ b/supabase/functions/generate-conflict-scenario/index.ts
@@ -26,9 +26,9 @@ serve(async (req) => {
       );
     }
 
-    const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
-    if (!LOVABLE_API_KEY) {
-      throw new Error("LOVABLE_API_KEY is not configured");
+    const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
+    if (!OPENAI_API_KEY) {
+      throw new Error("OPENAI_API_KEY is not configured");
     }
 
     // Build archetype summaries with value tensions
@@ -83,14 +83,14 @@ Make the conflict feel real and the characters feel alive.`;
 
     console.log("Generating conflict scenario for:", archetypes.map(a => a.name).join(", "));
 
-    const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "google/gemini-2.5-flash",
+        model: "gpt-4o-mini",
         messages: [
           { role: "system", content: systemPrompt },
           { role: "user", content: userPrompt },

--- a/supabase/functions/generate-persona-scenario/index.ts
+++ b/supabase/functions/generate-persona-scenario/index.ts
@@ -50,9 +50,9 @@ serve(async (req) => {
       );
     }
 
-    const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
-    if (!LOVABLE_API_KEY) {
-      throw new Error("LOVABLE_API_KEY is not configured");
+    const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
+    if (!OPENAI_API_KEY) {
+      throw new Error("OPENAI_API_KEY is not configured");
     }
 
     // Build persona summaries
@@ -120,14 +120,14 @@ Make each perspective genuinely reflect that persona's value system. Show how th
     console.log("Generating persona scenario for:", personas.map(p => p.name).join(" vs "));
     console.log("Carriers:", carriers.map(c => c.name).join(", "));
 
-    const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "google/gemini-2.5-flash",
+        model: "gpt-4o-mini",
         messages: [
           { role: "system", content: systemPrompt },
           { role: "user", content: userPrompt },


### PR DESCRIPTION
Migrate 3 Edge Functions from Lovable AI gateway to OpenAI API:
- compare-archetypes
- generate-conflict-scenario
- generate-persona-scenario

Changes for each function:
- API endpoint: ai.gateway.lovable.dev → api.openai.com
- Environment variable: LOVABLE_API_KEY → OPENAI_API_KEY
- Model: google/gemini-2.5-flash → gpt-4o-mini

All other parameters (streaming, message structure, error handling) unchanged.

https://claude.ai/code/session_01XxzyqeZcc68V1GjVTe8pAN