### PR TITLE
Add navigation menu to the homepage

### DIFF
--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -9,6 +9,7 @@ import { Json } from '@/integrations/supabase/types';
 import { ARCHETYPES, ARCHETYPE_CATEGORIES, archetypeToScores } from '@/lib/archetypes';
 import { useToast } from '@/hooks/use-toast';
 import { SchwartzCircle } from '@/components/SchwartzCircle';
+import { Navigation } from '@/components/Navigation';
 
 function jsonToScores(json: Json): ValueScores {
   return json as unknown as ValueScores;
@@ -84,6 +85,11 @@ export default function Landing() {
 
   return (
     <div className="min-h-screen bg-background">
+      <Navigation
+        title="Exploring Values"
+        description="A philosophical experiment on human values"
+      />
+
       {/* Hero Section */}
       <header className="relative overflow-hidden">
         <div className="absolute inset-0 gradient-hero opacity-5" />


### PR DESCRIPTION
The Landing page was the only page missing the Navigation component, making it impossible to navigate to other sections from the homepage without using browser navigation. This adds the same sticky header menu used by all other pages.

https://claude.ai/code/session_01ATzuTxWEjAt7C6qb4PKqna