### PR TITLE
Rename Tension Carrier → Stressor throughout codebase

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { BrowserRouter, HashRouter, Routes, Route } from "react-router-dom";
 import Landing from "./pages/Landing";
 import Index from "./pages/Index";
 import Compare from "./pages/Compare";
-import Carriers from "./pages/Carriers";
+import Stressors from "./pages/Stressors";
 import ExploreScenarios from "./pages/ExploreScenarios";
 import SharedProfile from "./pages/SharedProfile";
 import DataExport from "./pages/DataExport";
@@ -32,7 +32,7 @@ const App = () => {
             <Route path="/" element={<Landing />} />
             <Route path="/editor" element={<Index />} />
             <Route path="/compare" element={<Compare />} />
-            <Route path="/carriers" element={<Carriers />} />
+            <Route path="/stressors" element={<Stressors />} />
             <Route path="/scenarios" element={<ExploreScenarios />} />
             <Route path="/p/:id" element={<SharedProfile />} />
             <Route path="/export" element={<DataExport />} />

--- a/src/components/ClarificationPanel.tsx
+++ b/src/components/ClarificationPanel.tsx
@@ -9,18 +9,18 @@ import {
   analyzeForClarification,
   calculateUpdatedScores,
   responseToStrength,
-  selectOptimalCarriers,
-  CarrierSpreadInfo,
+  selectOptimalStressors,
+  StressorSpreadInfo,
   UndecidedValue,
 } from '@/lib/job-clarification';
-import { CarrierId } from '@/lib/carriers';
+import { StressorId } from '@/lib/stressors';
 import { toast } from 'sonner';
 
 const CLARIFICATION_URL = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-clarification-scenarios`;
 
 interface Scenario {
-  carrierId: string;
-  carrierName: string;
+  stressorId: string;
+  stressorName: string;
   setup: string;
   optionA: string;
   optionB: string;
@@ -43,18 +43,18 @@ export function ClarificationPanel({
   confidence,
   onScoresUpdate,
 }: ClarificationPanelProps) {
-  const [maxCarriers, setMaxCarriers] = useState(4);
+  const [maxStressors, setMaxStressors] = useState(4);
   const [minSpread, setMinSpread] = useState(0.8);
   const [scenarios, setScenarios] = useState<Scenario[]>([]);
   const [responses, setResponses] = useState<Record<string, ResponseValue>>({});
   const [isGenerating, setIsGenerating] = useState(false);
-  const [regeneratingCarrier, setRegeneratingCarrier] = useState<string | null>(null);
+  const [regeneratingStressor, setRegeneratingStressor] = useState<string | null>(null);
   const [showExplanation, setShowExplanation] = useState(false);
   const [selectedValueCodes, setSelectedValueCodes] = useState<Set<string>>(new Set());
   // Store the analysis snapshot used when generating scenarios
   const [generatedAnalysis, setGeneratedAnalysis] = useState<{
     undecidedValues: UndecidedValue[];
-    selectedCarriers: CarrierSpreadInfo[];
+    selectedStressors: StressorSpreadInfo[];
   } | null>(null);
 
   // Get all undecided values first (before filtering)
@@ -69,7 +69,7 @@ export function ClarificationPanel({
     if (selectedValueCodes.size === 0) {
       return {
         undecidedValues: [],
-        selectedCarriers: [],
+        selectedStressors: [],
         canClarify: false,
         reason: 'Select at least 2 values to clarify.',
       };
@@ -80,30 +80,30 @@ export function ClarificationPanel({
     if (valuesToUse.length < 2) {
       return {
         undecidedValues: valuesToUse,
-        selectedCarriers: [],
+        selectedStressors: [],
         canClarify: false,
         reason: 'Select at least 2 values to generate meaningful comparisons.',
       };
     }
 
-    // Use selectOptimalCarriers with filtered values
-    const carriers = selectOptimalCarriers(valuesToUse, maxCarriers, minSpread);
+    // Use selectOptimalStressors with filtered values
+    const stressors = selectOptimalStressors(valuesToUse, maxStressors, minSpread);
 
-    if (carriers.length === 0) {
+    if (stressors.length === 0) {
       return {
         undecidedValues: valuesToUse,
-        selectedCarriers: [],
+        selectedStressors: [],
         canClarify: false,
-        reason: `No carriers meet the minimum spread threshold of ${minSpread}. Try lowering the threshold.`,
+        reason: `No stressors meet the minimum spread threshold of ${minSpread}. Try lowering the threshold.`,
       };
     }
 
     return {
       undecidedValues: valuesToUse,
-      selectedCarriers: carriers,
+      selectedStressors: stressors,
       canClarify: true,
     };
-  }, [allUndecidedAnalysis, selectedValueCodes, maxCarriers, minSpread]);
+  }, [allUndecidedAnalysis, selectedValueCodes, maxStressors, minSpread]);
 
   // Toggle value selection
   const toggleValueSelection = (code: string) => {
@@ -146,11 +146,11 @@ export function ClarificationPanel({
     let updatedScores = { ...scores };
     const undecidedCodes = analysisToUse.undecidedValues.map(v => v.code);
 
-    for (const [carrierId, response] of Object.entries(responses)) {
+    for (const [stressorId, response] of Object.entries(responses)) {
       const strength = responseToStrength(response);
       updatedScores = calculateUpdatedScores(
         updatedScores,
-        carrierId as CarrierId,
+        stressorId as StressorId,
         strength,
         undecidedCodes
       );
@@ -169,7 +169,7 @@ export function ClarificationPanel({
     // Store the current analysis snapshot
     setGeneratedAnalysis({
       undecidedValues: analysis.undecidedValues,
-      selectedCarriers: analysis.selectedCarriers,
+      selectedStressors: analysis.selectedStressors,
     });
 
     try {
@@ -181,10 +181,10 @@ export function ClarificationPanel({
         },
         body: JSON.stringify({
           jobDescription,
-          carriers: analysis.selectedCarriers.map(c => ({
-            carrierId: c.carrierId,
-            carrierName: c.carrierName,
-            carrierDescription: c.carrierDescription,
+          stressors: analysis.selectedStressors.map(c => ({
+            stressorId: c.stressorId,
+            stressorName: c.stressorName,
+            stressorDescription: c.stressorDescription,
             highPolarityValues: c.highPolarityValues,
             lowPolarityValues: c.lowPolarityValues,
           })),
@@ -207,13 +207,13 @@ export function ClarificationPanel({
     }
   };
 
-  const regenerateScenario = async (carrierId: string) => {
+  const regenerateScenario = async (stressorId: string) => {
     // Use stored analysis if available, otherwise fall back to current
     const analysisToUse = generatedAnalysis || analysis;
-    const carrier = analysisToUse.selectedCarriers.find(c => c.carrierId === carrierId);
-    if (!carrier) return;
+    const stressor = analysisToUse.selectedStressors.find(c => c.stressorId === stressorId);
+    if (!stressor) return;
 
-    setRegeneratingCarrier(carrierId);
+    setRegeneratingStressor(stressorId);
 
     try {
       const response = await fetch(CLARIFICATION_URL, {
@@ -224,12 +224,12 @@ export function ClarificationPanel({
         },
         body: JSON.stringify({
           jobDescription,
-          carriers: [{
-            carrierId: carrier.carrierId,
-            carrierName: carrier.carrierName,
-            carrierDescription: carrier.carrierDescription,
-            highPolarityValues: carrier.highPolarityValues,
-            lowPolarityValues: carrier.lowPolarityValues,
+          stressors: [{
+            stressorId: stressor.stressorId,
+            stressorName: stressor.stressorName,
+            stressorDescription: stressor.stressorDescription,
+            highPolarityValues: stressor.highPolarityValues,
+            lowPolarityValues: stressor.lowPolarityValues,
           }],
         }),
       });
@@ -244,24 +244,24 @@ export function ClarificationPanel({
 
       if (newScenario) {
         setScenarios(prev =>
-          prev.map(s => (s.carrierId === carrierId ? newScenario : s))
+          prev.map(s => (s.stressorId === stressorId ? newScenario : s))
         );
-        // Clear response for this carrier since scenario changed
+        // Clear response for this stressor since scenario changed
         setResponses(prev => {
           const updated = { ...prev };
-          delete updated[carrierId];
+          delete updated[stressorId];
           return updated;
         });
       }
     } catch (error) {
       toast.error('Failed to regenerate scenario');
     } finally {
-      setRegeneratingCarrier(null);
+      setRegeneratingStressor(null);
     }
   };
 
-  const handleResponse = (carrierId: string, value: ResponseValue) => {
-    setResponses(prev => ({ ...prev, [carrierId]: value }));
+  const handleResponse = (stressorId: string, value: ResponseValue) => {
+    setResponses(prev => ({ ...prev, [stressorId]: value }));
   };
 
   const applyUpdatedScores = () => {
@@ -314,19 +314,19 @@ export function ClarificationPanel({
             the role prioritizes. Values marked "medium" or "unspecified" confidence need clarification.
           </p>
           <p>
-            <strong>The solution:</strong> We identify "tension carriers" - situational dimensions
+            <strong>The solution:</strong> We identify "stressors" - situational dimensions
             that force trade-offs between different values. By presenting scenarios that activate
-            these carriers, we can infer which values the role actually emphasizes.
+            these stressors, we can infer which values the role actually emphasizes.
           </p>
           <p>
-            <strong>How carriers are selected:</strong> For each carrier, we calculate its "spread" -
-            how much the undecided values differ in their response to that carrier. Higher spread
-            means the carrier better differentiates between values. We select carriers with the
+            <strong>How stressors are selected:</strong> For each stressor, we calculate its "spread" -
+            how much the undecided values differ in their response to that stressor. Higher spread
+            means the stressor better differentiates between values. We select stressors with the
             highest spread.
           </p>
           <p>
             <strong>How scores update:</strong> When you respond to a scenario, values with positive
-            polarity on that carrier increase, while values with negative polarity decrease.
+            polarity on that stressor increase, while values with negative polarity decrease.
             The strength of your response (strongly/somewhat) determines the magnitude.
           </p>
         </div>
@@ -391,12 +391,12 @@ export function ClarificationPanel({
         <div className="grid md:grid-cols-2 gap-6">
           <div className="space-y-2">
             <div className="flex justify-between text-sm">
-              <span>Maximum carriers</span>
-              <span className="font-medium">{maxCarriers}</span>
+              <span>Maximum stressors</span>
+              <span className="font-medium">{maxStressors}</span>
             </div>
             <Slider
-              value={[maxCarriers]}
-              onValueChange={([v]) => setMaxCarriers(v)}
+              value={[maxStressors]}
+              onValueChange={([v]) => setMaxStressors(v)}
               min={1}
               max={8}
               step={1}
@@ -419,10 +419,10 @@ export function ClarificationPanel({
       )}
 
       {/* Polarity matrix - showing our work */}
-      {analysis.selectedCarriers.length > 0 && (
+      {analysis.selectedStressors.length > 0 && (
         <div>
           <h3 className="text-sm font-medium mb-2">
-            Value × Carrier Polarity Matrix
+            Value × Stressor Polarity Matrix
             <span className="font-normal text-muted-foreground ml-2">
               (spread shown in header)
             </span>
@@ -432,9 +432,9 @@ export function ClarificationPanel({
               <thead>
                 <tr>
                   <th className="text-left p-2 border-b">Value</th>
-                  {analysis.selectedCarriers.map(c => (
-                    <th key={c.carrierId} className="p-2 border-b text-center">
-                      <div>{c.carrierName}</div>
+                  {analysis.selectedStressors.map(c => (
+                    <th key={c.stressorId} className="p-2 border-b text-center">
+                      <div>{c.stressorName}</div>
                       <div className="text-muted-foreground font-normal">
                         spread: {c.spread.toFixed(2)}
                       </div>
@@ -446,11 +446,11 @@ export function ClarificationPanel({
                 {analysis.undecidedValues.map(value => (
                   <tr key={value.code}>
                     <td className="p-2 border-b font-medium">{value.label}</td>
-                    {analysis.selectedCarriers.map(carrier => {
-                      const polarityInfo = carrier.allPolarities.find(p => p.code === value.code);
+                    {analysis.selectedStressors.map(stressor => {
+                      const polarityInfo = stressor.allPolarities.find(p => p.code === value.code);
                       const polarity = polarityInfo?.polarity ?? 0;
                       return (
-                        <td key={carrier.carrierId} className="p-2 border-b text-center">
+                        <td key={stressor.stressorId} className="p-2 border-b text-center">
                           <span
                             className={`inline-block px-2 py-0.5 rounded ${getPolarityColor(polarity)}`}
                           >
@@ -494,30 +494,30 @@ export function ClarificationPanel({
           <h3 className="text-sm font-medium">Clarifying Scenarios to pose to the hiring manager</h3>
 
           {scenarios.map(scenario => {
-            const carrier = generatedAnalysis.selectedCarriers.find(
-              c => c.carrierId === scenario.carrierId
+            const stressor = generatedAnalysis.selectedStressors.find(
+              c => c.stressorId === scenario.stressorId
             );
-            const currentResponse = responses[scenario.carrierId];
+            const currentResponse = responses[scenario.stressorId];
 
             return (
-              <Card key={scenario.carrierId} className="p-4 space-y-4">
+              <Card key={scenario.stressorId} className="p-4 space-y-4">
                 <div className="flex items-start justify-between">
                   <div>
-                    <h4 className="font-medium text-primary">{scenario.carrierName}</h4>
+                    <h4 className="font-medium text-primary">{scenario.stressorName}</h4>
                     <p className="text-xs text-muted-foreground">
                       Differentiates:{' '}
-                      {carrier?.highPolarityValues.map(v => v.label).join(', ') || 'values'}
+                      {stressor?.highPolarityValues.map(v => v.label).join(', ') || 'values'}
                       {' vs '}
-                      {carrier?.lowPolarityValues.map(v => v.label).join(', ') || 'values'}
+                      {stressor?.lowPolarityValues.map(v => v.label).join(', ') || 'values'}
                     </p>
                   </div>
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => regenerateScenario(scenario.carrierId)}
-                    disabled={regeneratingCarrier === scenario.carrierId}
+                    onClick={() => regenerateScenario(scenario.stressorId)}
+                    disabled={regeneratingStressor === scenario.stressorId}
                   >
-                    {regeneratingCarrier === scenario.carrierId ? (
+                    {regeneratingStressor === scenario.stressorId ? (
                       <Loader2 className="w-4 h-4 animate-spin" />
                     ) : (
                       <RefreshCw className="w-4 h-4" />
@@ -557,7 +557,7 @@ export function ClarificationPanel({
                       return (
                         <button
                           key={value}
-                          onClick={() => handleResponse(scenario.carrierId, value)}
+                          onClick={() => handleResponse(scenario.stressorId, value)}
                           className={`px-3 py-1.5 text-xs rounded transition-colors ${
                             isSelected
                               ? value <= 2

--- a/src/components/GenerationPanel.tsx
+++ b/src/components/GenerationPanel.tsx
@@ -6,7 +6,7 @@ import { ValueScores } from '@/lib/schwartz-values';
 import { generateDescription, generateSystemPrompt } from '@/lib/profile-generator';
 import { SimilarTo } from '@/components/SimilarTo';
 import { ValueEditor } from '@/components/ValueEditor';
-import { CarrierSensitivityPanel } from '@/components/CarrierSensitivityPanel';
+import { StressorSensitivityPanel } from '@/components/StressorSensitivityPanel';
 import { useToast } from '@/hooks/use-toast';
 
 interface GenerationPanelProps {
@@ -96,9 +96,9 @@ export function GenerationPanel({
         </section>
       )}
 
-      {/* Carrier Sensitivity Analysis */}
+      {/* Stressor Sensitivity Analysis */}
       <section className="rounded-xl border bg-card p-6">
-        <CarrierSensitivityPanel scores={scores} />
+        <StressorSensitivityPanel scores={scores} />
       </section>
 
       {/* Copy Instructions - system prompt */}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -20,7 +20,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/', label: 'Home', description: 'Landing page', icon: Home },
   { to: '/editor', label: 'Profile Editor', description: 'Create and edit value profiles', icon: Compass },
   { to: '/compare', label: 'Compare Profiles', description: 'Compare two profiles side-by-side', icon: Users },
-  { to: '/carriers', label: 'Tension Carriers', description: 'Explore value polarities', icon: Layers },
+  { to: '/stressors', label: 'Stressors', description: 'Explore value polarities', icon: Layers },
   { to: '/scenarios', label: 'Explore Scenarios', description: 'AI-generated conflict scenarios', icon: Sparkles },
   { to: '/job-analysis', label: 'Job Analysis', description: 'Analyze job descriptions', icon: Briefcase },
   { to: '/export', label: 'Data Export', description: 'Export profiles as JSON', icon: FileDown },

--- a/src/components/ProfileStressors.tsx
+++ b/src/components/ProfileStressors.tsx
@@ -2,9 +2,9 @@ import { useMemo, useState } from 'react';
 import { ChevronDown, Swords, Users } from 'lucide-react';
 import { ValueScores } from '@/lib/schwartz-values';
 import {
-  getTopProfileTensionCarriers,
-  ProfileTensionCarrier,
-} from '@/lib/carrier-sensitivity';
+  getTopProfileStressors,
+  ProfileStressor,
+} from '@/lib/stressor-sensitivity';
 import {
   Collapsible,
   CollapsibleContent,
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
 
-interface ProfileTensionCarriersProps {
+interface ProfileStressorsProps {
   profiles: { name: string; scores: ValueScores }[];
 }
 
@@ -66,19 +66,19 @@ function ProfileSensitivityDot({
   );
 }
 
-function TensionCarrierCard({ 
-  carrier, 
+function TensionStressorCard({ 
+  stressor, 
   maxTension,
   maxSensitivity,
 }: { 
-  carrier: ProfileTensionCarrier; 
+  stressor: ProfileStressor; 
   maxTension: number;
   maxSensitivity: number;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   
-  const tensionLevel = carrier.tensionScore >= maxTension * 0.7 ? 'high' 
-    : carrier.tensionScore >= maxTension * 0.4 ? 'moderate' 
+  const tensionLevel = stressor.tensionScore >= maxTension * 0.7 ? 'high' 
+    : stressor.tensionScore >= maxTension * 0.4 ? 'moderate' 
     : 'low';
   
   return (
@@ -95,11 +95,11 @@ function TensionCarrierCard({
               <Swords className="w-5 h-5" />
             </div>
             <div className="flex-1 text-left min-w-0">
-              <h4 className="font-medium text-sm truncate">{carrier.carrierName}</h4>
+              <h4 className="font-medium text-sm truncate">{stressor.stressorName}</h4>
               <div className="flex items-center gap-2 mt-1">
-                <TensionBar value={carrier.tensionScore} max={maxTension} />
+                <TensionBar value={stressor.tensionScore} max={maxTension} />
                 <span className="text-xs text-muted-foreground font-mono w-12 text-right">
-                  {carrier.tensionScore.toFixed(2)}
+                  {stressor.tensionScore.toFixed(2)}
                 </span>
               </div>
             </div>
@@ -121,7 +121,7 @@ function TensionCarrierCard({
                   {/* Center line */}
                   <div className="absolute left-1/2 top-0 bottom-0 w-px bg-border" />
                   {/* Profile dots */}
-                  {carrier.profileSensitivities.map((ps, i) => (
+                  {stressor.profileSensitivities.map((ps, i) => (
                     <ProfileSensitivityDot 
                       key={i}
                       name={ps.profileName}
@@ -143,10 +143,10 @@ function TensionCarrierCard({
                   <Users className="w-4 h-4 text-muted-foreground" />
                   <span className="text-muted-foreground">Highest conflict:</span>
                   <span className="font-medium">
-                    {carrier.conflictingProfiles[0]} vs {carrier.conflictingProfiles[1]}
+                    {stressor.conflictingProfiles[0]} vs {stressor.conflictingProfiles[1]}
                   </span>
                   <span className="text-muted-foreground ml-auto">
-                    Δ{carrier.conflictMagnitude.toFixed(2)}
+                    Δ{stressor.conflictMagnitude.toFixed(2)}
                   </span>
                 </div>
               </div>
@@ -158,22 +158,22 @@ function TensionCarrierCard({
   );
 }
 
-export function ProfileTensionCarriers({ profiles }: ProfileTensionCarriersProps) {
-  const tensionCarriers = useMemo(
-    () => getTopProfileTensionCarriers(profiles, 6),
+export function ProfileStressors({ profiles }: ProfileStressorsProps) {
+  const tensionStressors = useMemo(
+    () => getTopProfileStressors(profiles, 6),
     [profiles]
   );
   
   const maxTension = useMemo(() => {
-    return Math.max(...tensionCarriers.map(c => c.tensionScore), 0.1);
-  }, [tensionCarriers]);
+    return Math.max(...tensionStressors.map(c => c.tensionScore), 0.1);
+  }, [tensionStressors]);
   
   const maxSensitivity = useMemo(() => {
-    const allSensitivities = tensionCarriers.flatMap(c => 
+    const allSensitivities = tensionStressors.flatMap(c => 
       c.profileSensitivities.map(ps => Math.abs(ps.sensitivity))
     );
     return Math.max(...allSensitivities, 0.5);
-  }, [tensionCarriers]);
+  }, [tensionStressors]);
   
   if (profiles.length < 2) {
     return null;
@@ -182,17 +182,17 @@ export function ProfileTensionCarriers({ profiles }: ProfileTensionCarriersProps
   return (
     <div className="rounded-xl border bg-card p-6">
       <h2 className="font-serif text-lg font-semibold mb-2">
-        Tension-Amplifying Carriers
+        Tension-Amplifying Stressors
       </h2>
       <p className="text-sm text-muted-foreground mb-4">
-        These carriers would most amplify conflicts between the selected profiles. 
+        These stressors would most amplify conflicts between the selected profiles. 
         Scenarios involving these pressures will reveal the sharpest value differences.
       </p>
       <div className="space-y-2">
-        {tensionCarriers.map(carrier => (
-          <TensionCarrierCard 
-            key={carrier.carrierId} 
-            carrier={carrier} 
+        {tensionStressors.map(stressor => (
+          <TensionStressorCard 
+            key={stressor.stressorId} 
+            stressor={stressor} 
             maxTension={maxTension}
             maxSensitivity={maxSensitivity}
           />

--- a/src/components/StressorSensitivityPanel.tsx
+++ b/src/components/StressorSensitivityPanel.tsx
@@ -3,12 +3,12 @@ import { Link } from 'react-router-dom';
 import { ChevronDown, Zap, TrendingUp, ArrowUpDown, ArrowRight } from 'lucide-react';
 import { ValueScores } from '@/lib/schwartz-values';
 import {
-  getTopSensitiveCarriers,
-  getTopInternalTensionCarriers,
-  CarrierSensitivity,
-  CarrierInternalTension,
-} from '@/lib/carrier-sensitivity';
-import { CARRIERS, CarrierId } from '@/lib/carriers';
+  getTopSensitiveStressors,
+  getTopInternalTensionStressors,
+  StressorSensitivity,
+  StressorInternalTension,
+} from '@/lib/stressor-sensitivity';
+import { STRESSORS, StressorId } from '@/lib/stressors';
 import { ValueAbbreviation } from '@/components/ValueAbbreviation';
 import {
   Collapsible,
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
 
-interface CarrierSensitivityPanelProps {
+interface StressorSensitivityPanelProps {
   scores: ValueScores;
 }
 
@@ -43,8 +43,8 @@ function SensitivityBar({ value, max }: { value: number; max: number }) {
   );
 }
 
-function TopCarrierCard({ sensitivity, maxSensitivity }: { 
-  sensitivity: CarrierSensitivity; 
+function TopStressorCard({ sensitivity, maxSensitivity }: { 
+  sensitivity: StressorSensitivity; 
   maxSensitivity: number;
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -62,9 +62,9 @@ function TopCarrierCard({ sensitivity, maxSensitivity }: {
               {isPositive ? <TrendingUp className="w-4 h-4" /> : <Zap className="w-4 h-4" />}
             </div>
             <div className="flex-1 text-left min-w-0">
-              <h4 className="font-medium text-sm truncate">{sensitivity.carrierName}</h4>
+              <h4 className="font-medium text-sm truncate">{sensitivity.stressorName}</h4>
               <p className="text-xs text-muted-foreground line-clamp-2 mb-1">
-                {CARRIERS[sensitivity.carrierId as CarrierId]?.description}
+                {STRESSORS[sensitivity.stressorId as StressorId]?.description}
               </p>
               <SensitivityBar value={sensitivity.totalSensitivity} max={maxSensitivity} />
             </div>
@@ -103,7 +103,7 @@ function TopCarrierCard({ sensitivity, maxSensitivity }: {
   );
 }
 
-function InternalTensionCard({ tension }: { tension: CarrierInternalTension }) {
+function InternalTensionCard({ tension }: { tension: StressorInternalTension }) {
   const [isOpen, setIsOpen] = useState(false);
   
   return (
@@ -115,9 +115,9 @@ function InternalTensionCard({ tension }: { tension: CarrierInternalTension }) {
               <ArrowUpDown className="w-4 h-4" />
             </div>
             <div className="flex-1 text-left min-w-0">
-              <h4 className="font-medium text-sm truncate">{tension.carrierName}</h4>
+              <h4 className="font-medium text-sm truncate">{tension.stressorName}</h4>
               <p className="text-xs text-muted-foreground line-clamp-2 mb-1">
-                {CARRIERS[tension.carrierId as CarrierId]?.description}
+                {STRESSORS[tension.stressorId as StressorId]?.description}
               </p>
               <p className="text-xs text-muted-foreground">
                 Range: {tension.range.toFixed(2)} (σ: {tension.standardDeviation.toFixed(3)})
@@ -154,7 +154,7 @@ function InternalTensionCard({ tension }: { tension: CarrierInternalTension }) {
                 </div>
               </div>
               <p className="text-xs text-muted-foreground mt-2">
-                This carrier creates internal conflict between your high and low priority values.
+                This stressor creates internal conflict between your high and low priority values.
               </p>
             </div>
           </div>
@@ -164,36 +164,36 @@ function InternalTensionCard({ tension }: { tension: CarrierInternalTension }) {
   );
 }
 
-export function CarrierSensitivityPanel({ scores }: CarrierSensitivityPanelProps) {
-  const topCarriers = useMemo(() => getTopSensitiveCarriers(scores, 5), [scores]);
-  const internalTensions = useMemo(() => getTopInternalTensionCarriers(scores, 5), [scores]);
+export function StressorSensitivityPanel({ scores }: StressorSensitivityPanelProps) {
+  const topStressors = useMemo(() => getTopSensitiveStressors(scores, 5), [scores]);
+  const internalTensions = useMemo(() => getTopInternalTensionStressors(scores, 5), [scores]);
   
   const maxSensitivity = useMemo(() => {
-    return Math.max(...topCarriers.map(c => c.absoluteSensitivity), 0.1);
-  }, [topCarriers]);
+    return Math.max(...topStressors.map(c => c.absoluteSensitivity), 0.1);
+  }, [topStressors]);
   
   return (
     <div className="space-y-6">
-      {/* Top Sensitive Carriers */}
+      {/* Top Sensitive Stressors */}
       <div>
         <h3 className="font-serif text-lg font-semibold mb-2">
-          Carrier Sensitivity
+          Stressor Sensitivity
         </h3>
         <p className="text-sm text-muted-foreground mb-3">
-          These carriers have the strongest effect on this profile. Positive values indicate 
-          the carrier satisfies the profile's values; negative values indicate frustration.
+          These stressors have the strongest effect on this profile. Positive values indicate 
+          the stressor satisfies the profile's values; negative values indicate frustration.
         </p>
         <Link 
-          to="/carriers" 
+          to="/stressors" 
           className="inline-flex items-center gap-1 text-sm text-primary hover:underline mb-4"
         >
-          Explore Tension Carriers
+          Explore Stressors
           <ArrowRight className="w-3 h-3" />
         </Link>
         <div className="space-y-2">
-          {topCarriers.map(sensitivity => (
-            <TopCarrierCard 
-              key={sensitivity.carrierId} 
+          {topStressors.map(sensitivity => (
+            <TopStressorCard 
+              key={sensitivity.stressorId} 
               sensitivity={sensitivity} 
               maxSensitivity={maxSensitivity}
             />
@@ -201,18 +201,18 @@ export function CarrierSensitivityPanel({ scores }: CarrierSensitivityPanelProps
         </div>
       </div>
       
-      {/* Internal Tension Carriers */}
+      {/* Internal Stressors */}
       <div>
         <h3 className="font-serif text-lg font-semibold mb-2">
-          Internal Tension Carriers
+          Internal Stressors
         </h3>
         <p className="text-sm text-muted-foreground mb-4">
-          These carriers create the most internal conflict within this profile—situations 
+          These stressors create the most internal conflict within this profile—situations 
           where your high-priority values respond very differently.
         </p>
         <div className="space-y-2">
           {internalTensions.map(tension => (
-            <InternalTensionCard key={tension.carrierId} tension={tension} />
+            <InternalTensionCard key={tension.stressorId} tension={tension} />
           ))}
         </div>
       </div>

--- a/src/lib/job-clarification.ts
+++ b/src/lib/job-clarification.ts
@@ -1,20 +1,20 @@
 /**
  * Job Clarification Logic
  *
- * This module implements the algorithm for identifying which tension carriers
+ * This module implements the algorithm for identifying which stressors
  * would best help clarify undecided values in a job description analysis.
  *
- * Algorithm: Maximum Spread Carrier Selection
- * - For each carrier, calculate the "spread" of polarities across undecided values
- * - Spread = max(polarities) - min(polarities) for that carrier
- * - Select carriers with highest spread, as they best differentiate the undecided values
+ * Algorithm: Maximum Spread Stressor Selection
+ * - For each stressor, calculate the "spread" of polarities across undecided values
+ * - Spread = max(polarities) - min(polarities) for that stressor
+ * - Select stressors with highest spread, as they best differentiate the undecided values
  *
  * Note: Future enhancement could use variance instead of range for spread calculation.
  * See GitHub issue for discussion of variance vs range tradeoffs.
  */
 
 import { ValueScores, getValueByCode } from './schwartz-values';
-import { CarrierId, CARRIERS, getPolarity } from './carriers';
+import { StressorId, STRESSORS, getPolarity } from './stressors';
 
 export type ConfidenceLevel = 'high' | 'medium' | 'unspecified';
 
@@ -25,10 +25,10 @@ export interface UndecidedValue {
   confidence: ConfidenceLevel;
 }
 
-export interface CarrierSpreadInfo {
-  carrierId: CarrierId;
-  carrierName: string;
-  carrierDescription: string;
+export interface StressorSpreadInfo {
+  stressorId: StressorId;
+  stressorName: string;
+  stressorDescription: string;
   spread: number;
   minPolarity: number;
   maxPolarity: number;
@@ -39,7 +39,7 @@ export interface CarrierSpreadInfo {
 
 export interface ClarificationResult {
   undecidedValues: UndecidedValue[];
-  selectedCarriers: CarrierSpreadInfo[];
+  selectedStressors: StressorSpreadInfo[];
   canClarify: boolean;
   reason?: string;
 }
@@ -71,20 +71,20 @@ export function identifyUndecidedValues(
 }
 
 /**
- * Calculate spread for a single carrier across undecided values
+ * Calculate spread for a single stressor across undecided values
  * Spread = max(polarities) - min(polarities)
- * Higher spread means the carrier better differentiates the values
+ * Higher spread means the stressor better differentiates the values
  */
-function calculateCarrierSpread(
-  carrierId: CarrierId,
+function calculateStressorSpread(
+  stressorId: StressorId,
   undecidedValues: UndecidedValue[]
-): CarrierSpreadInfo {
-  const carrier = CARRIERS[carrierId];
+): StressorSpreadInfo {
+  const stressor = STRESSORS[stressorId];
 
   const polarities = undecidedValues.map(v => ({
     code: v.code,
     label: v.label,
-    polarity: getPolarity(v.code, carrierId),
+    polarity: getPolarity(v.code, stressorId),
   }));
 
   const polarityValues = polarities.map(p => p.polarity);
@@ -102,9 +102,9 @@ function calculateCarrierSpread(
     .sort((a, b) => a.polarity - b.polarity);
 
   return {
-    carrierId,
-    carrierName: carrier.name,
-    carrierDescription: carrier.description,
+    stressorId,
+    stressorName: stressor.name,
+    stressorDescription: stressor.description,
     spread,
     minPolarity,
     maxPolarity,
@@ -115,35 +115,35 @@ function calculateCarrierSpread(
 }
 
 /**
- * Select optimal carriers that maximize differentiation of undecided values
+ * Select optimal stressors that maximize differentiation of undecided values
  *
  * @param undecidedValues - Values with medium/unspecified confidence
- * @param maxCarriers - Maximum number of carriers to select (default 4)
- * @param minSpread - Minimum spread threshold to consider a carrier useful (default 0.8)
- * @returns Ranked list of carriers with their spread info
+ * @param maxStressors - Maximum number of stressors to select (default 4)
+ * @param minSpread - Minimum spread threshold to consider a stressor useful (default 0.8)
+ * @returns Ranked list of stressors with their spread info
  */
-export function selectOptimalCarriers(
+export function selectOptimalStressors(
   undecidedValues: UndecidedValue[],
-  maxCarriers: number = 4,
+  maxStressors: number = 4,
   minSpread: number = 0.8
-): CarrierSpreadInfo[] {
+): StressorSpreadInfo[] {
   if (undecidedValues.length < 2) {
     return [];
   }
 
-  // Calculate spread for all carriers
-  const carrierIds = Object.keys(CARRIERS) as CarrierId[];
-  const allCarrierSpreads = carrierIds.map(id =>
-    calculateCarrierSpread(id, undecidedValues)
+  // Calculate spread for all stressors
+  const stressorIds = Object.keys(STRESSORS) as StressorId[];
+  const allStressorSpreads = stressorIds.map(id =>
+    calculateStressorSpread(id, undecidedValues)
   );
 
   // Sort by spread descending and filter by minimum threshold
-  const qualifyingCarriers = allCarrierSpreads
+  const qualifyingStressors = allStressorSpreads
     .filter(c => c.spread >= minSpread)
     .sort((a, b) => b.spread - a.spread);
 
-  // Return top N carriers
-  return qualifyingCarriers.slice(0, maxCarriers);
+  // Return top N stressors
+  return qualifyingStressors.slice(0, maxStressors);
 }
 
 /**
@@ -152,7 +152,7 @@ export function selectOptimalCarriers(
 export function analyzeForClarification(
   scores: ValueScores,
   confidence: Record<string, ConfidenceLevel>,
-  maxCarriers: number = 4,
+  maxStressors: number = 4,
   minSpread: number = 0.8
 ): ClarificationResult {
   const undecidedValues = identifyUndecidedValues(scores, confidence);
@@ -160,7 +160,7 @@ export function analyzeForClarification(
   if (undecidedValues.length === 0) {
     return {
       undecidedValues: [],
-      selectedCarriers: [],
+      selectedStressors: [],
       canClarify: false,
       reason: 'All values have high confidence - no clarification needed.',
     };
@@ -169,26 +169,26 @@ export function analyzeForClarification(
   if (undecidedValues.length === 1) {
     return {
       undecidedValues,
-      selectedCarriers: [],
+      selectedStressors: [],
       canClarify: false,
       reason: 'Only one undecided value - need at least two to generate meaningful comparisons.',
     };
   }
 
-  const selectedCarriers = selectOptimalCarriers(undecidedValues, maxCarriers, minSpread);
+  const selectedStressors = selectOptimalStressors(undecidedValues, maxStressors, minSpread);
 
-  if (selectedCarriers.length === 0) {
+  if (selectedStressors.length === 0) {
     return {
       undecidedValues,
-      selectedCarriers: [],
+      selectedStressors: [],
       canClarify: false,
-      reason: `No carriers meet the minimum spread threshold of ${minSpread}. Try lowering the threshold.`,
+      reason: `No stressors meet the minimum spread threshold of ${minSpread}. Try lowering the threshold.`,
     };
   }
 
   return {
     undecidedValues,
-    selectedCarriers,
+    selectedStressors,
     canClarify: true,
   };
 }
@@ -200,21 +200,21 @@ export function analyzeForClarification(
  * Where responseStrength ranges from -1.0 (strongly favor B) to +1.0 (strongly favor A)
  *
  * @param currentScores - Current value scores
- * @param carrierId - The carrier used in the scenario
+ * @param stressorId - The stressor used in the scenario
  * @param responseStrength - User's response: -1.0 to +1.0
  * @param undecidedValueCodes - Only update these values
  * @returns Updated scores object
  */
 export function calculateUpdatedScores(
   currentScores: ValueScores,
-  carrierId: CarrierId,
+  stressorId: StressorId,
   responseStrength: number,
   undecidedValueCodes: string[]
 ): ValueScores {
   const updatedScores = { ...currentScores };
 
   for (const code of undecidedValueCodes) {
-    const polarity = getPolarity(code, carrierId);
+    const polarity = getPolarity(code, stressorId);
     // Skip values without polarity data to avoid NaN
     if (polarity === undefined) continue;
 

--- a/src/lib/polarity-explanations.ts
+++ b/src/lib/polarity-explanations.ts
@@ -2,17 +2,17 @@
  * Polarity Explanations
  * 
  * This file provides human-readable explanations for why each value
- * has a particular polarity score on each carrier. These explanations
+ * has a particular polarity score on each stressor. These explanations
  * help users understand the psychological rationale behind the mappings.
  */
 
-import { CarrierId } from './carriers';
+import { StressorId } from './stressors';
 
 /**
- * Each explanation describes why increasing the carrier's intensity
+ * Each explanation describes why increasing the stressor's intensity
  * tends to satisfy (+) or frustrate (-) the value.
  */
-export type PolarityExplanationMap = Record<string, Record<CarrierId, string>>;
+export type PolarityExplanationMap = Record<string, Record<StressorId, string>>;
 
 export const POLARITY_EXPLANATIONS: PolarityExplanationMap = {
   // =========================================================================
@@ -318,8 +318,8 @@ export const POLARITY_EXPLANATIONS: PolarityExplanationMap = {
 };
 
 /**
- * Get the explanation for a specific value-carrier polarity.
+ * Get the explanation for a specific value-stressor polarity.
  */
-export function getPolarityExplanation(valueCode: string, carrierId: CarrierId): string | undefined {
-  return POLARITY_EXPLANATIONS[valueCode]?.[carrierId];
+export function getPolarityExplanation(valueCode: string, stressorId: StressorId): string | undefined {
+  return POLARITY_EXPLANATIONS[valueCode]?.[stressorId];
 }

--- a/src/lib/stressor-sensitivity.ts
+++ b/src/lib/stressor-sensitivity.ts
@@ -1,22 +1,22 @@
 /**
- * Carrier Sensitivity Analysis
+ * Stressor Sensitivity Analysis
  * 
  * This module provides functions to analyze how a value profile (a set of weighted values)
- * interacts with carriers. It calculates:
+ * interacts with stressors. It calculates:
  * 
- * 1. Value-Weighted Carrier Matrix: Adjusts the polarity matrix based on value weights
- * 2. Carrier Sensitivity Vector: Total weighted polarity for each carrier
- * 3. Internal Tension Carriers: Carriers with high variance in sensitivity
- * 4. Profile Tension Carriers: Carriers that antagonize tensions between profiles
+ * 1. Value-Weighted Stressor Matrix: Adjusts the polarity matrix based on value weights
+ * 2. Stressor Sensitivity Vector: Total weighted polarity for each stressor
+ * 3. Internal Stressors: Stressors with high variance in sensitivity
+ * 4. Profile Stressors: Stressors that antagonize tensions between profiles
  */
 
 import { 
-  CarrierId, 
-  CARRIER_IDS, 
-  CARRIERS,
+  StressorId, 
+  STRESSOR_IDS, 
+  STRESSORS,
   VALUE_POLARITY_MAP,
   getPolarity,
-} from './carriers';
+} from './stressors';
 import { 
   ValueScores, 
   SCHWARTZ_VALUES,
@@ -24,28 +24,28 @@ import {
 } from './schwartz-values';
 
 /**
- * Represents a single cell in the value-weighted carrier matrix
+ * Represents a single cell in the value-weighted stressor matrix
  */
 export interface WeightedPolarityCell {
   valueCode: string;
-  carrierId: CarrierId;
+  stressorId: StressorId;
   rawPolarity: number;
   valueWeight: number;
   weightedPolarity: number;
 }
 
 /**
- * The full value-weighted carrier matrix
+ * The full value-weighted stressor matrix
  */
-export type ValueWeightedCarrierMatrix = WeightedPolarityCell[];
+export type ValueWeightedStressorMatrix = WeightedPolarityCell[];
 
 /**
- * A sensitivity score for a carrier, with contributing values
+ * A sensitivity score for a stressor, with contributing values
  */
-export interface CarrierSensitivity {
-  carrierId: CarrierId;
-  carrierName: string;
-  /** Total weighted polarity - positive means carrier satisfies profile, negative frustrates */
+export interface StressorSensitivity {
+  stressorId: StressorId;
+  stressorName: string;
+  /** Total weighted polarity - positive means stressor satisfies profile, negative frustrates */
   totalSensitivity: number;
   /** Absolute magnitude of sensitivity */
   absoluteSensitivity: number;
@@ -60,11 +60,11 @@ export interface CarrierSensitivity {
 }
 
 /**
- * Internal tension analysis for a carrier
+ * Internal tension analysis for a stressor
  */
-export interface CarrierInternalTension {
-  carrierId: CarrierId;
-  carrierName: string;
+export interface StressorInternalTension {
+  stressorId: StressorId;
+  stressorName: string;
   /** Range of weighted polarities (max - min) */
   range: number;
   /** Standard deviation of weighted polarities */
@@ -75,19 +75,19 @@ export interface CarrierInternalTension {
 }
 
 /**
- * Profile tension carrier - a carrier that antagonizes tensions between profiles
+ * Profile stressor - a stressor that antagonizes tensions between profiles
  */
-export interface ProfileTensionCarrier {
-  carrierId: CarrierId;
-  carrierName: string;
-  /** How much this carrier would amplify the tension between profiles */
+export interface ProfileStressor {
+  stressorId: StressorId;
+  stressorName: string;
+  /** How much this stressor would amplify the tension between profiles */
   tensionScore: number;
   /** Per-profile sensitivities */
   profileSensitivities: {
     profileName: string;
     sensitivity: number;
   }[];
-  /** The profiles most in conflict on this carrier */
+  /** The profiles most in conflict on this stressor */
   conflictingProfiles: [string, string];
   conflictMagnitude: number;
 }
@@ -102,25 +102,25 @@ function normalizeScoreToWeight(score: number): number {
 }
 
 /**
- * Calculate the value-weighted carrier matrix for a given profile.
+ * Calculate the value-weighted stressor matrix for a given profile.
  * 
  * This adjusts each polarity by the normalized weight of each value in the profile.
  */
-export function calculateWeightedCarrierMatrix(
+export function calculateWeightedStressorMatrix(
   scores: ValueScores
-): ValueWeightedCarrierMatrix {
-  const matrix: ValueWeightedCarrierMatrix = [];
+): ValueWeightedStressorMatrix {
+  const matrix: ValueWeightedStressorMatrix = [];
   
   for (const value of SCHWARTZ_VALUES) {
     const valueWeight = normalizeScoreToWeight(scores[value.code] ?? 3.5);
     
-    for (const carrierId of CARRIER_IDS) {
-      const rawPolarity = getPolarity(value.code, carrierId) ?? 0;
+    for (const stressorId of STRESSOR_IDS) {
+      const rawPolarity = getPolarity(value.code, stressorId) ?? 0;
       const weightedPolarity = rawPolarity * valueWeight;
       
       matrix.push({
         valueCode: value.code,
-        carrierId,
+        stressorId,
         rawPolarity,
         valueWeight,
         weightedPolarity,
@@ -132,27 +132,27 @@ export function calculateWeightedCarrierMatrix(
 }
 
 /**
- * Calculate the carrier sensitivity vector for a profile.
+ * Calculate the stressor sensitivity vector for a profile.
  * 
- * For each carrier, this sums the weighted polarities across all values
- * to get the total sensitivity of the profile to that carrier.
+ * For each stressor, this sums the weighted polarities across all values
+ * to get the total sensitivity of the profile to that stressor.
  */
-export function calculateCarrierSensitivityVector(
+export function calculateStressorSensitivityVector(
   scores: ValueScores,
   topContributorCount: number = 5
-): CarrierSensitivity[] {
-  const matrix = calculateWeightedCarrierMatrix(scores);
+): StressorSensitivity[] {
+  const matrix = calculateWeightedStressorMatrix(scores);
   
-  const sensitivities: CarrierSensitivity[] = CARRIER_IDS.map(carrierId => {
-    const carrierCells = matrix.filter(cell => cell.carrierId === carrierId);
+  const sensitivities: StressorSensitivity[] = STRESSOR_IDS.map(stressorId => {
+    const stressorCells = matrix.filter(cell => cell.stressorId === stressorId);
     
-    const totalSensitivity = carrierCells.reduce(
+    const totalSensitivity = stressorCells.reduce(
       (sum, cell) => sum + cell.weightedPolarity,
       0
     );
     
     // Get top contributors sorted by absolute contribution
-    const contributions = carrierCells
+    const contributions = stressorCells
       .map(cell => ({
         valueCode: cell.valueCode,
         valueLabel: getValueByCode(cell.valueCode)?.label ?? cell.valueCode,
@@ -164,8 +164,8 @@ export function calculateCarrierSensitivityVector(
       .slice(0, topContributorCount);
     
     return {
-      carrierId,
-      carrierName: CARRIERS[carrierId].name,
+      stressorId,
+      stressorName: STRESSORS[stressorId].name,
       totalSensitivity,
       absoluteSensitivity: Math.abs(totalSensitivity),
       topContributors: contributions,
@@ -177,30 +177,30 @@ export function calculateCarrierSensitivityVector(
 }
 
 /**
- * Get the top N most sensitive carriers for a profile.
+ * Get the top N most sensitive stressors for a profile.
  */
-export function getTopSensitiveCarriers(
+export function getTopSensitiveStressors(
   scores: ValueScores,
   count: number = 5
-): CarrierSensitivity[] {
-  return calculateCarrierSensitivityVector(scores).slice(0, count);
+): StressorSensitivity[] {
+  return calculateStressorSensitivityVector(scores).slice(0, count);
 }
 
 /**
- * Calculate internal tension carriers - those with the biggest range of
+ * Calculate internal stressors - those with the biggest range of
  * weighted polarities within a profile.
  * 
  * High internal tension means the profile has values that respond very
- * differently to the same carrier, creating internal conflict.
+ * differently to the same stressor, creating internal conflict.
  */
-export function calculateInternalTensionCarriers(
+export function calculateInternalTensionStressors(
   scores: ValueScores
-): CarrierInternalTension[] {
-  const matrix = calculateWeightedCarrierMatrix(scores);
+): StressorInternalTension[] {
+  const matrix = calculateWeightedStressorMatrix(scores);
   
-  const tensions: CarrierInternalTension[] = CARRIER_IDS.map(carrierId => {
-    const carrierCells = matrix.filter(cell => cell.carrierId === carrierId);
-    const weightedPolarities = carrierCells.map(c => c.weightedPolarity);
+  const tensions: StressorInternalTension[] = STRESSOR_IDS.map(stressorId => {
+    const stressorCells = matrix.filter(cell => cell.stressorId === stressorId);
+    const weightedPolarities = stressorCells.map(c => c.weightedPolarity);
     
     const max = Math.max(...weightedPolarities);
     const min = Math.min(...weightedPolarities);
@@ -211,12 +211,12 @@ export function calculateInternalTensionCarriers(
     const variance = weightedPolarities.reduce((s, v) => s + Math.pow(v - mean, 2), 0) / weightedPolarities.length;
     const standardDeviation = Math.sqrt(variance);
     
-    const highestCell = carrierCells.find(c => c.weightedPolarity === max)!;
-    const lowestCell = carrierCells.find(c => c.weightedPolarity === min)!;
+    const highestCell = stressorCells.find(c => c.weightedPolarity === max)!;
+    const lowestCell = stressorCells.find(c => c.weightedPolarity === min)!;
     
     return {
-      carrierId,
-      carrierName: CARRIERS[carrierId].name,
+      stressorId,
+      stressorName: STRESSORS[stressorId].name,
       range,
       standardDeviation,
       highestValue: {
@@ -237,35 +237,35 @@ export function calculateInternalTensionCarriers(
 }
 
 /**
- * Get the top N carriers with highest internal tension.
+ * Get the top N stressors with highest internal tension.
  */
-export function getTopInternalTensionCarriers(
+export function getTopInternalTensionStressors(
   scores: ValueScores,
   count: number = 5
-): CarrierInternalTension[] {
-  return calculateInternalTensionCarriers(scores).slice(0, count);
+): StressorInternalTension[] {
+  return calculateInternalTensionStressors(scores).slice(0, count);
 }
 
 /**
- * Calculate which carriers most antagonize the tensions between multiple profiles.
+ * Calculate which stressors most antagonize the tensions between multiple profiles.
  * 
- * This finds carriers where profiles have opposing sensitivities,
- * meaning the carrier would pull them in different directions.
+ * This finds stressors where profiles have opposing sensitivities,
+ * meaning the stressor would pull them in different directions.
  */
-export function calculateProfileTensionCarriers(
+export function calculateProfileStressors(
   profiles: { name: string; scores: ValueScores }[]
-): ProfileTensionCarrier[] {
+): ProfileStressor[] {
   if (profiles.length < 2) return [];
   
   // Calculate sensitivity for each profile
   const profileSensitivities = profiles.map(profile => ({
     name: profile.name,
-    sensitivities: calculateCarrierSensitivityVector(profile.scores),
+    sensitivities: calculateStressorSensitivityVector(profile.scores),
   }));
   
-  const tensionCarriers: ProfileTensionCarrier[] = CARRIER_IDS.map(carrierId => {
-    const carrierSensitivities = profileSensitivities.map(ps => {
-      const sens = ps.sensitivities.find(s => s.carrierId === carrierId);
+  const tensionStressors: ProfileStressor[] = STRESSOR_IDS.map(stressorId => {
+    const stressorSensitivities = profileSensitivities.map(ps => {
+      const sens = ps.sensitivities.find(s => s.stressorId === stressorId);
       return {
         profileName: ps.name,
         sensitivity: sens?.totalSensitivity ?? 0,
@@ -276,16 +276,16 @@ export function calculateProfileTensionCarriers(
     let maxDiff = 0;
     let conflictingProfiles: [string, string] = [profiles[0].name, profiles[1].name];
     
-    for (let i = 0; i < carrierSensitivities.length; i++) {
-      for (let j = i + 1; j < carrierSensitivities.length; j++) {
+    for (let i = 0; i < stressorSensitivities.length; i++) {
+      for (let j = i + 1; j < stressorSensitivities.length; j++) {
         const diff = Math.abs(
-          carrierSensitivities[i].sensitivity - carrierSensitivities[j].sensitivity
+          stressorSensitivities[i].sensitivity - stressorSensitivities[j].sensitivity
         );
         if (diff > maxDiff) {
           maxDiff = diff;
           conflictingProfiles = [
-            carrierSensitivities[i].profileName,
-            carrierSensitivities[j].profileName,
+            stressorSensitivities[i].profileName,
+            stressorSensitivities[j].profileName,
           ];
         }
       }
@@ -293,34 +293,34 @@ export function calculateProfileTensionCarriers(
     
     // Calculate overall tension score (sum of all pairwise differences)
     let tensionScore = 0;
-    for (let i = 0; i < carrierSensitivities.length; i++) {
-      for (let j = i + 1; j < carrierSensitivities.length; j++) {
+    for (let i = 0; i < stressorSensitivities.length; i++) {
+      for (let j = i + 1; j < stressorSensitivities.length; j++) {
         tensionScore += Math.abs(
-          carrierSensitivities[i].sensitivity - carrierSensitivities[j].sensitivity
+          stressorSensitivities[i].sensitivity - stressorSensitivities[j].sensitivity
         );
       }
     }
     
     return {
-      carrierId,
-      carrierName: CARRIERS[carrierId].name,
+      stressorId,
+      stressorName: STRESSORS[stressorId].name,
       tensionScore,
-      profileSensitivities: carrierSensitivities,
+      profileSensitivities: stressorSensitivities,
       conflictingProfiles,
       conflictMagnitude: maxDiff,
     };
   });
   
   // Sort by tension score (highest first)
-  return tensionCarriers.sort((a, b) => b.tensionScore - a.tensionScore);
+  return tensionStressors.sort((a, b) => b.tensionScore - a.tensionScore);
 }
 
 /**
- * Get the top N carriers that most antagonize profile tensions.
+ * Get the top N stressors that most antagonize profile tensions.
  */
-export function getTopProfileTensionCarriers(
+export function getTopProfileStressors(
   profiles: { name: string; scores: ValueScores }[],
   count: number = 5
-): ProfileTensionCarrier[] {
-  return calculateProfileTensionCarriers(profiles).slice(0, count);
+): ProfileStressor[] {
+  return calculateProfileStressors(profiles).slice(0, count);
 }

--- a/src/lib/stressors.ts
+++ b/src/lib/stressors.ts
@@ -1,36 +1,36 @@
 /**
- * Carriers: Decision-Space Primitives for Value-Scenario Generation
+ * Stressors: Decision-Space Primitives for Value-Scenario Generation
  * 
  * CONCEPTUAL FRAMEWORK:
  * 
  * Schwartz values exist in MOTIVATION SPACE — they describe what people care about.
  * But values alone don't predict behavior; they require a DECISION CONTEXT.
  * 
- * Carriers exist in DECISION SPACE — they represent forms of scarcity, constraint,
+ * Stressors exist in DECISION SPACE — they represent forms of scarcity, constraint,
  * or tension that force tradeoffs and make latent value differences behaviorally salient.
  * 
- * Without a relevant carrier, two people with different values may behave identically
- * (no scarcity = no forced choice). Carriers are the "pressure" that reveals values.
+ * Without a relevant stressor, two people with different values may behave identically
+ * (no scarcity = no forced choice). Stressors are the "pressure" that reveals values.
  * 
  * POLARITY VECTORS:
  * 
- * A polarity vector maps each Schwartz value to each carrier, indicating how
- * increasing that carrier's intensity tends to satisfy (+) or frustrate (-) the value.
+ * A polarity vector maps each Schwartz value to each stressor, indicating how
+ * increasing that stressor's intensity tends to satisfy (+) or frustrate (-) the value.
  * 
  * Example: Humility has negative polarity on Attention/Recognition because
  * increasing public attention frustrates the humble person's preference to
  * recognize their insignificance in the larger scheme.
  * 
- * These vectors are used to SELECT which carrier best exposes a given value-value
- * tension. If two values have opposite polarities on a carrier, that carrier
+ * These vectors are used to SELECT which stressor best exposes a given value-value
+ * tension. If two values have opposite polarities on a stressor, that stressor
  * will make their conflict behaviorally visible.
  */
 
 // ============================================================================
-// CARRIER TYPES
+// STRESSOR TYPES
 // ============================================================================
 
-export type CarrierId = 
+export type StressorId = 
   | 'risk_uncertainty'
   | 'control_authority'
   | 'resources_allocation'
@@ -44,7 +44,7 @@ export type CarrierId =
   | 'change_stability'
   | 'boundary_permeability';
 
-export interface CarrierParameter {
+export interface StressorParameter {
   id: string;
   name: string;
   description: string;
@@ -56,25 +56,25 @@ export interface CarrierParameter {
   defaultValue: number;
 }
 
-export interface Carrier {
-  id: CarrierId;
+export interface Stressor {
+  id: StressorId;
   name: string;
   description: string;
-  /** A concrete example scenario illustrating this carrier in action */
+  /** A concrete example scenario illustrating this stressor in action */
   example: string;
   /** 
-   * Parameters that can be tuned to intensify or soften the carrier.
-   * Each parameter represents a dimension of the carrier that affects
+   * Parameters that can be tuned to intensify or soften the stressor.
+   * Each parameter represents a dimension of the stressor that affects
    * how strongly it creates decision pressure.
    */
-  parameters: CarrierParameter[];
+  parameters: StressorParameter[];
 }
 
 // ============================================================================
-// CARRIER DEFINITIONS
+// STRESSOR DEFINITIONS
 // ============================================================================
 
-export const CARRIERS: Record<CarrierId, Carrier> = {
+export const STRESSORS: Record<StressorId, Stressor> = {
   risk_uncertainty: {
     id: 'risk_uncertainty',
     name: 'Risk / Uncertainty',
@@ -472,55 +472,55 @@ export const CARRIERS: Record<CarrierId, Carrier> = {
   },
 };
 
-export const CARRIER_IDS: CarrierId[] = Object.keys(CARRIERS) as CarrierId[];
+export const STRESSOR_IDS: StressorId[] = Object.keys(STRESSORS) as StressorId[];
 
 // ============================================================================
 // POLARITY VECTOR TYPES
 // ============================================================================
 
 /**
- * A polarity score indicates how a carrier's increase affects a value.
+ * A polarity score indicates how a stressor's increase affects a value.
  * 
  * Range: -1.0 to +1.0
  * 
- * +1.0 = Increasing this carrier strongly SATISFIES the value
- * +0.5 = Increasing this carrier moderately satisfies the value
- *  0.0 = The carrier is orthogonal / weakly related to the value
- * -0.5 = Increasing this carrier moderately FRUSTRATES the value
- * -1.0 = Increasing this carrier strongly frustrates the value
+ * +1.0 = Increasing this stressor strongly SATISFIES the value
+ * +0.5 = Increasing this stressor moderately satisfies the value
+ *  0.0 = The stressor is orthogonal / weakly related to the value
+ * -0.5 = Increasing this stressor moderately FRUSTRATES the value
+ * -1.0 = Increasing this stressor strongly frustrates the value
  * 
  * USAGE:
- * To find which carrier best exposes a value-value tension, look for carriers
+ * To find which stressor best exposes a value-value tension, look for stressors
  * where the two values have OPPOSITE polarities. The larger the difference,
  * the more visible the conflict will be in that decision context.
  */
 export type PolarityScore = number; // -1.0 to +1.0
 
 /**
- * Maps each carrier to a polarity score for a given value.
+ * Maps each stressor to a polarity score for a given value.
  */
-export type PolarityVector = Record<CarrierId, PolarityScore>;
+export type PolarityVector = Record<StressorId, PolarityScore>;
 
 /**
- * Maps each Schwartz value code to its polarity vector over all carriers.
+ * Maps each Schwartz value code to its polarity vector over all stressors.
  */
 export type ValuePolarityMap = Record<string, PolarityVector>;
 
 // ============================================================================
-// VALUE-CARRIER POLARITY MAPPINGS
+// VALUE-STRESSOR POLARITY MAPPINGS
 // ============================================================================
 
 /**
  * POLARITY VECTORS FOR ALL 19 SCHWARTZ VALUES
  * 
- * These mappings encode how each value relates to each carrier dimension.
- * They are used to SELECT appropriate carriers for exposing value conflicts,
+ * These mappings encode how each value relates to each stressor dimension.
+ * They are used to SELECT appropriate stressors for exposing value conflicts,
  * not to define the conflicts themselves (which exist in motivation space).
  * 
  * Derivation notes:
  * - Positive polarity: the value is advanced when this scarcity/constraint increases
  * - Negative polarity: the value is frustrated when this scarcity/constraint increases
- * - Near-zero: the carrier doesn't strongly relate to this value's core concern
+ * - Near-zero: the stressor doesn't strongly relate to this value's core concern
  */
 export const VALUE_POLARITY_MAP: ValuePolarityMap = {
   // =========================================================================
@@ -856,25 +856,25 @@ export function getPolarityVector(valueCode: string): PolarityVector | undefined
 }
 
 /**
- * Get a specific polarity score for a value-carrier pair.
+ * Get a specific polarity score for a value-stressor pair.
  */
-export function getPolarity(valueCode: string, carrierId: CarrierId): PolarityScore | undefined {
-  return VALUE_POLARITY_MAP[valueCode]?.[carrierId];
+export function getPolarity(valueCode: string, stressorId: StressorId): PolarityScore | undefined {
+  return VALUE_POLARITY_MAP[valueCode]?.[stressorId];
 }
 
 /**
- * Calculate the polarity difference between two values on a carrier.
- * Larger absolute values indicate that this carrier would expose greater tension.
+ * Calculate the polarity difference between two values on a stressor.
+ * Larger absolute values indicate that this stressor would expose greater tension.
  * 
  * @returns Difference in polarity (-2.0 to +2.0), or undefined if values not found
  */
 export function getPolarityDifference(
   valueCodeA: string, 
   valueCodeB: string, 
-  carrierId: CarrierId
+  stressorId: StressorId
 ): number | undefined {
-  const polarityA = getPolarity(valueCodeA, carrierId);
-  const polarityB = getPolarity(valueCodeB, carrierId);
+  const polarityA = getPolarity(valueCodeA, stressorId);
+  const polarityB = getPolarity(valueCodeB, stressorId);
   
   if (polarityA === undefined || polarityB === undefined) return undefined;
   
@@ -882,24 +882,24 @@ export function getPolarityDifference(
 }
 
 /**
- * Find the carriers that would best expose a tension between two values.
- * Returns carriers sorted by the absolute polarity difference (highest first).
+ * Find the stressors that would best expose a tension between two values.
+ * Returns stressors sorted by the absolute polarity difference (highest first).
  * 
  * This is the key function for scenario generation: given two values in conflict,
  * it identifies which decision contexts would make that conflict behaviorally visible.
  */
-export function findBestCarriersForTension(
+export function findBestStressorsForTension(
   valueCodeA: string,
   valueCodeB: string,
   limit: number = 3
-): Array<{ carrier: Carrier; polarityDiff: number }> {
-  const results: Array<{ carrier: Carrier; polarityDiff: number }> = [];
+): Array<{ stressor: Stressor; polarityDiff: number }> {
+  const results: Array<{ stressor: Stressor; polarityDiff: number }> = [];
   
-  for (const carrierId of CARRIER_IDS) {
-    const diff = getPolarityDifference(valueCodeA, valueCodeB, carrierId);
+  for (const stressorId of STRESSOR_IDS) {
+    const diff = getPolarityDifference(valueCodeA, valueCodeB, stressorId);
     if (diff !== undefined) {
       results.push({
-        carrier: CARRIERS[carrierId],
+        stressor: STRESSORS[stressorId],
         polarityDiff: diff,
       });
     }
@@ -912,15 +912,15 @@ export function findBestCarriersForTension(
 }
 
 /**
- * Get all carrier definitions as an array.
+ * Get all stressor definitions as an array.
  */
-export function getCarriers(): Carrier[] {
-  return Object.values(CARRIERS);
+export function getStressors(): Stressor[] {
+  return Object.values(STRESSORS);
 }
 
 /**
- * Get a carrier by its ID.
+ * Get a stressor by its ID.
  */
-export function getCarrierById(id: CarrierId): Carrier | undefined {
-  return CARRIERS[id];
+export function getStressorById(id: StressorId): Stressor | undefined {
+  return STRESSORS[id];
 }

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -6,7 +6,7 @@ import { Navigation } from '@/components/Navigation';
 import { ARCHETYPES, ARCHETYPE_CATEGORIES, archetypeToScores } from '@/lib/archetypes';
 import { OverlappingSchwartzCircle } from '@/components/OverlappingSchwartzCircle';
 import { ConflictScenario } from '@/components/ConflictScenario';
-import { ProfileTensionCarriers } from '@/components/ProfileTensionCarriers';
+import { ProfileStressors } from '@/components/ProfileStressors';
 import { ValueScores } from '@/lib/schwartz-values';
 import { toast } from 'sonner';
 
@@ -366,8 +366,8 @@ export default function Compare() {
                   )}
                 </div>
 
-                {/* Tension-Amplifying Carriers */}
-                <ProfileTensionCarriers profiles={selectedArchetypeData} />
+                {/* Tension-Amplifying Stressors */}
+                <ProfileStressors profiles={selectedArchetypeData} />
 
                 <ConflictScenario selectedArchetypes={selectedArchetypes} customProfiles={customProfiles} />
               </>

--- a/src/pages/ExploreScenarios.tsx
+++ b/src/pages/ExploreScenarios.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { ARCHETYPES, ARCHETYPE_CATEGORIES, Archetype } from '@/lib/archetypes';
 import { SCHWARTZ_VALUES } from '@/lib/schwartz-values';
-import { CARRIERS, VALUE_POLARITY_MAP, CarrierId, findBestCarriersForTension, getCarrierById } from '@/lib/carriers';
+import { STRESSORS, VALUE_POLARITY_MAP, StressorId, findBestStressorsForTension, getStressorById } from '@/lib/stressors';
 import { OverlappingSchwartzCircle } from '@/components/OverlappingSchwartzCircle';
 import { ValueAbbreviation } from '@/components/ValueAbbreviation';
 import { toast } from 'sonner';
@@ -21,12 +21,12 @@ interface TensionLine {
   valueA: string;
   valueB: string;
   scoreDiff: number;
-  carriers: Array<{ carrierId: CarrierId; polarityDiff: number }>;
+  stressors: Array<{ stressorId: StressorId; polarityDiff: number }>;
 }
 
 export default function ExploreScenarios() {
   const [selectedPersonas, setSelectedPersonas] = useState<string[]>([]);
-  const [selectedCarriers, setSelectedCarriers] = useState<CarrierId[]>([]);
+  const [selectedStressors, setSelectedStressors] = useState<StressorId[]>([]);
   const [scenario, setScenario] = useState<string>('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [expandedCategories, setExpandedCategories] = useState<string[]>(['fictional']);
@@ -126,14 +126,14 @@ export default function ExploreScenarios() {
         
         // Only consider significant tensions
         if (combinedTension > 1.0) {
-          const carrierImpacts = findBestCarriersForTension(valueA.code, valueB.code, 3);
+          const stressorImpacts = findBestStressorsForTension(valueA.code, valueB.code, 3);
           
           tensions.push({
             valueA: valueA.code,
             valueB: valueB.code,
             scoreDiff: combinedTension,
-            carriers: carrierImpacts.map(c => ({
-              carrierId: c.carrier.id as CarrierId,
+            stressors: stressorImpacts.map(c => ({
+              stressorId: c.stressor.id as StressorId,
               polarityDiff: c.polarityDiff,
             })),
           });
@@ -147,23 +147,23 @@ export default function ExploreScenarios() {
       .slice(0, 3);
   }, [personaData]);
 
-  // Get all carriers that impact the tensions
-  const impactingCarriers = useMemo(() => {
-    const carrierMap = new Map<CarrierId, { carrier: typeof CARRIERS[CarrierId]; tensions: string[] }>();
+  // Get all stressors that impact the tensions
+  const impactingStressors = useMemo(() => {
+    const stressorMap = new Map<StressorId, { stressor: typeof STRESSORS[StressorId]; tensions: string[] }>();
     
     tensionLines.forEach(tension => {
-      tension.carriers.forEach(({ carrierId }) => {
-        const carrier = CARRIERS[carrierId];
-        if (carrier) {
-          if (!carrierMap.has(carrierId)) {
-            carrierMap.set(carrierId, { carrier, tensions: [] });
+      tension.stressors.forEach(({ stressorId }) => {
+        const stressor = STRESSORS[stressorId];
+        if (stressor) {
+          if (!stressorMap.has(stressorId)) {
+            stressorMap.set(stressorId, { stressor, tensions: [] });
           }
-          carrierMap.get(carrierId)!.tensions.push(`${tension.valueA} vs ${tension.valueB}`);
+          stressorMap.get(stressorId)!.tensions.push(`${tension.valueA} vs ${tension.valueB}`);
         }
       });
     });
     
-    return Array.from(carrierMap.entries()).map(([id, data]) => ({
+    return Array.from(stressorMap.entries()).map(([id, data]) => ({
       id,
       ...data,
     }));
@@ -179,26 +179,26 @@ export default function ExploreScenarios() {
       }
       return [...prev, name];
     });
-    // Reset carriers when personas change
-    setSelectedCarriers([]);
+    // Reset stressors when personas change
+    setSelectedStressors([]);
     setScenario('');
   };
 
-  const toggleCarrier = (carrierId: CarrierId) => {
-    setSelectedCarriers(prev => 
-      prev.includes(carrierId) 
-        ? prev.filter(c => c !== carrierId)
-        : [...prev, carrierId]
+  const toggleStressor = (stressorId: StressorId) => {
+    setSelectedStressors(prev => 
+      prev.includes(stressorId) 
+        ? prev.filter(c => c !== stressorId)
+        : [...prev, stressorId]
     );
   };
 
-  const selectAllCarriers = () => {
-    setSelectedCarriers(impactingCarriers.map(c => c.id));
+  const selectAllStressors = () => {
+    setSelectedStressors(impactingStressors.map(c => c.id));
   };
 
   const generateScenario = async () => {
-    if (personaData.length !== 2 || selectedCarriers.length === 0) {
-      toast.error('Select 2 personas and at least 1 carrier');
+    if (personaData.length !== 2 || selectedStressors.length === 0) {
+      toast.error('Select 2 personas and at least 1 stressor');
       return;
     }
 
@@ -206,21 +206,21 @@ export default function ExploreScenarios() {
     setScenario('');
 
     try {
-      const carriers = selectedCarriers.map(id => {
-        const carrier = CARRIERS[id];
+      const stressors = selectedStressors.map(id => {
+        const stressor = STRESSORS[id];
         return {
           id,
-          name: carrier.name,
-          description: carrier.description,
+          name: stressor.name,
+          description: stressor.description,
         };
       });
 
       const tensions = tensionLines
-        .filter(t => t.carriers.some(c => selectedCarriers.includes(c.carrierId)))
+        .filter(t => t.stressors.some(c => selectedStressors.includes(c.stressorId)))
         .map(t => ({
           valueA: SCHWARTZ_VALUES.find(v => v.code === t.valueA)?.label || t.valueA,
           valueB: SCHWARTZ_VALUES.find(v => v.code === t.valueB)?.label || t.valueB,
-          carrier: t.carriers.find(c => selectedCarriers.includes(c.carrierId))?.carrierId || '',
+          stressor: t.stressors.find(c => selectedStressors.includes(c.stressorId))?.stressorId || '',
           explanation: `${personaData[0].name} values ${t.valueA} while ${personaData[1].name} values ${t.valueB}`,
         }));
 
@@ -233,7 +233,7 @@ export default function ExploreScenarios() {
             description: p.description,
             valueProfile: p.valueProfile,
           })),
-          carriers,
+          stressors,
           tensions,
         }),
       });
@@ -455,8 +455,8 @@ export default function ExploreScenarios() {
                         </span>
                       </div>
                       <p className="text-xs text-muted-foreground">
-                        Amplified by: {tension.carriers.map(c => 
-                          CARRIERS[c.carrierId]?.name
+                        Amplified by: {tension.stressors.map(c => 
+                          STRESSORS[c.stressorId]?.name
                         ).filter(Boolean).join(', ')}
                       </p>
                     </div>
@@ -465,31 +465,31 @@ export default function ExploreScenarios() {
               </Card>
             )}
 
-            {/* Impacting Carriers */}
-            {impactingCarriers.length > 0 && (
+            {/* Impacting Stressors */}
+            {impactingStressors.length > 0 && (
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center justify-between">
-                    <span>Select Carriers for Scenario</span>
-                    <Button variant="ghost" size="sm" onClick={selectAllCarriers}>
+                    <span>Select Stressors for Scenario</span>
+                    <Button variant="ghost" size="sm" onClick={selectAllStressors}>
                       Select All
                     </Button>
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-3">
-                  {impactingCarriers.map(({ id, carrier, tensions }) => (
+                  {impactingStressors.map(({ id, stressor, tensions }) => (
                     <label 
                       key={id}
                       className="flex items-start gap-3 p-3 rounded-lg border cursor-pointer hover:bg-muted/50 transition-colors"
                     >
                       <Checkbox
-                        checked={selectedCarriers.includes(id)}
-                        onCheckedChange={() => toggleCarrier(id)}
+                        checked={selectedStressors.includes(id)}
+                        onCheckedChange={() => toggleStressor(id)}
                         className="mt-1"
                       />
                       <div className="flex-1">
-                        <div className="font-medium">{carrier.name}</div>
-                        <p className="text-sm text-muted-foreground">{carrier.description}</p>
+                        <div className="font-medium">{stressor.name}</div>
+                        <p className="text-sm text-muted-foreground">{stressor.description}</p>
                         <p className="text-xs text-primary mt-1">
                           Aggravates: {tensions.join(', ')}
                         </p>
@@ -504,7 +504,7 @@ export default function ExploreScenarios() {
             {personaData.length === 2 && (
               <Button
                 onClick={generateScenario}
-                disabled={isGenerating || selectedCarriers.length === 0}
+                disabled={isGenerating || selectedStressors.length === 0}
                 className="w-full"
                 size="lg"
               >

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -116,7 +116,7 @@ export default function Landing() {
               This site is an interactive exploration of human values—what we care about, why it matters, 
               and how different value priorities create both harmony and conflict. Using Schwartz's 
               scientifically validated framework, you can map value profiles, discover tensions, and 
-              explore how values express themselves through everyday carriers like money, time, and attention.
+              explore how values express themselves through everyday stressors like money, time, and attention.
             </p>
           </div>
         </div>
@@ -149,11 +149,11 @@ export default function Landing() {
         </div>
       </section>
 
-      {/* Tensions & Carriers Section */}
+      {/* Tensions & Stressors Section */}
       <section className="py-12 border-t">
         <div className="container">
           <div className="max-w-3xl mx-auto">
-            <h2 className="font-serif text-2xl font-bold mb-6">Tensions & Carriers</h2>
+            <h2 className="font-serif text-2xl font-bold mb-6">Tensions & Stressors</h2>
             <div className="grid md:grid-cols-2 gap-8">
               <div>
                 <h3 className="font-semibold text-lg mb-3">Value Tensions</h3>
@@ -165,9 +165,9 @@ export default function Landing() {
                 </p>
               </div>
               <div>
-                <h3 className="font-semibold text-lg mb-3">Tension Carriers</h3>
+                <h3 className="font-semibold text-lg mb-3">Stressors</h3>
                 <p className="text-muted-foreground">
-                  Tension Carriers are forms of scarcity or constraint that force tradeoffs. They make 
+                  Stressors are forms of scarcity or constraint that force tradeoffs. They make 
                   latent value differences behaviorally visible by empowering or antagonising values 
                   in different ways.
                 </p>
@@ -201,10 +201,10 @@ export default function Landing() {
                   Visualize tensions between different value schemes and discover where conflicts arise.
                 </p>
               </Link>
-              <Link to="/carriers" className="group p-5 rounded-xl border bg-card hover:border-primary/30 hover:shadow-md transition-all">
+              <Link to="/stressors" className="group p-5 rounded-xl border bg-card hover:border-primary/30 hover:shadow-md transition-all">
                 <div className="flex items-center gap-3 mb-2">
                   <Layers className="w-5 h-5 text-primary" />
-                  <h3 className="font-semibold group-hover:text-primary transition-colors">Explore Tension Carriers</h3>
+                  <h3 className="font-semibold group-hover:text-primary transition-colors">Explore Stressors</h3>
                 </div>
                 <p className="text-sm text-muted-foreground">
                   Discover the constraints that force tradeoffs and make value differences visible.

--- a/src/pages/Research.tsx
+++ b/src/pages/Research.tsx
@@ -125,7 +125,7 @@ export default function Research() {
     <div className="min-h-screen bg-background">
       <Navigation
         title="Research Background"
-        description="Literature review of the tension carriers framework"
+        description="Literature review of the stressors framework"
       />
 
       {/* Introduction */}
@@ -136,9 +136,9 @@ export default function Research() {
             <div>
               <h2 className="font-semibold text-amber-900 dark:text-amber-200 mb-2">About This Review</h2>
               <p className="text-sm text-amber-800 dark:text-amber-300">
-                This page presents a research-grounded evaluation of the "tension carriers" concept used on this site.
+                This page presents a research-grounded evaluation of the "stressors" concept used on this site.
                 It reviews empirical and theoretical support, challenges and critiques, and comparable taxonomies
-                from psychology, organizational studies, and moral philosophy. The term "tension carriers" refers to
+                from psychology, organizational studies, and moral philosophy. The term "stressors" refers to
                 situational features that systematically activate, strain, or force trade-offs among values—rather
                 than being values themselves.
               </p>
@@ -148,7 +148,7 @@ export default function Research() {
           <div className="prose prose-gray dark:prose-invert max-w-none">
             <p className="text-lg text-muted-foreground">
               Below is a structured summary of the relevant academic literature, organized into three sections:
-              research that supports the idea of tension carriers, research that challenges or complicates the
+              research that supports the idea of stressors, research that challenges or complicates the
               framework, and comparable taxonomies that provide useful context.
             </p>
           </div>
@@ -162,7 +162,7 @@ export default function Research() {
             <div className="w-10 h-10 rounded-lg bg-emerald-100 dark:bg-emerald-900/50 flex items-center justify-center">
               <CheckCircle className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
             </div>
-            <h2 className="font-serif text-2xl font-bold">1. Research That Supports Tension Carriers</h2>
+            <h2 className="font-serif text-2xl font-bold">1. Research That Supports Stressors</h2>
           </div>
 
           <div className="prose prose-gray dark:prose-invert max-w-none space-y-8">
@@ -176,8 +176,8 @@ export default function Research() {
               <h3 className="font-serif text-lg font-semibold mb-4 mt-0">1.1 Moral Stress, Moral Uncertainty, and Value Strain</h3>
               <p className="text-muted-foreground">
                 Research on moral stress shows that tension arises not merely from conflicting values, but from
-                situational ambiguity, responsibility, and constraint—precisely the kind of "carrier" the
-                tension carriers taxonomy highlights.
+                situational ambiguity, responsibility, and constraint—precisely the kind of "stressor" the
+                stressors taxonomy highlights.
               </p>
               <ul className="text-muted-foreground space-y-3 mt-4">
                 <li>
@@ -216,7 +216,7 @@ export default function Research() {
                 </li>
               </ul>
               <p className="text-sm text-muted-foreground mt-4 italic">
-                This aligns strongly with the carrier metaphor: values are latent; situations load them.
+                This aligns strongly with the stressor metaphor: values are latent; situations load them.
               </p>
             </div>
 
@@ -260,7 +260,7 @@ export default function Research() {
 
             {/* 2.1 Individual differences */}
             <div className="p-6 rounded-xl border bg-card">
-              <h3 className="font-serif text-lg font-semibold mb-4 mt-0">2.1 Individual Differences Undermine Fixed Carrier Effects</h3>
+              <h3 className="font-serif text-lg font-semibold mb-4 mt-0">2.1 Individual Differences Undermine Fixed Stressor Effects</h3>
               <p className="text-muted-foreground">
                 One challenge is that the same situational feature does not produce the same tension for
                 all agents.
@@ -276,7 +276,7 @@ export default function Research() {
                 </li>
               </ul>
               <p className="text-sm font-medium text-amber-700 dark:text-amber-400 mt-4">
-                Implication: Tension carriers are probabilistic, not deterministic; they interact with
+                Implication: Tension stressors are probabilistic, not deterministic; they interact with
                 person-level variables.
               </p>
             </div>
@@ -298,7 +298,7 @@ export default function Research() {
                 </li>
               </ul>
               <p className="text-sm font-medium text-amber-700 dark:text-amber-400 mt-4">
-                Implication: A list of 12 carriers risks false precision unless explicitly framed as
+                Implication: A list of 12 stressors risks false precision unless explicitly framed as
                 analytical lenses rather than independent variables.
               </p>
             </div>
@@ -307,7 +307,7 @@ export default function Research() {
             <div className="p-6 rounded-xl border bg-card">
               <h3 className="font-serif text-lg font-semibold mb-4 mt-0">2.3 Cultural and Institutional Dependence</h3>
               <p className="text-muted-foreground">
-                What counts as a tension-carrier is culturally mediated.
+                What counts as a tension-stressor is culturally mediated.
               </p>
               <ul className="text-muted-foreground space-y-3 mt-4">
                 <li>
@@ -335,7 +335,7 @@ export default function Research() {
           </div>
 
           <p className="text-muted-foreground mb-8">
-            The tension carriers framework sits at the intersection of several established classification
+            The stressors framework sits at the intersection of several established classification
             traditions:
           </p>
 
@@ -353,7 +353,7 @@ export default function Research() {
                 <CitationLink id="jex2003" />
               </p>
               <p className="text-xs text-muted-foreground mt-2 italic">
-                These overlap strongly with carriers like conflicting obligations, uncertainty, and
+                These overlap strongly with stressors like conflicting obligations, uncertainty, and
                 resource constraints.
               </p>
             </div>
@@ -372,7 +372,7 @@ export default function Research() {
                 <CitationLink id="klenk2022" />
               </p>
               <p className="text-xs text-muted-foreground mt-2 italic">
-                These are near-isomorphic to several proposed carriers and provide empirical grounding.
+                These are near-isomorphic to several proposed stressors and provide empirical grounding.
               </p>
             </div>
 
@@ -388,7 +388,7 @@ export default function Research() {
                 <CitationLink id="bouckenooghe2005" />; <CitationLink id="lee2015" />
               </p>
               <p className="text-xs text-muted-foreground mt-2 italic">
-                These focus less on situations, but help explain why carriers produce strain.
+                These focus less on situations, but help explain why stressors produce strain.
               </p>
             </div>
 
@@ -405,7 +405,7 @@ export default function Research() {
                 <CitationLink id="myyry2007" />
               </p>
               <p className="text-xs text-muted-foreground mt-2 italic">
-                These are especially relevant if carriers include social exposure, contestation, or
+                These are especially relevant if stressors include social exposure, contestation, or
                 public accountability.
               </p>
             </div>
@@ -424,7 +424,7 @@ export default function Research() {
               <ul className="text-sm text-emerald-800 dark:text-emerald-300 space-y-2">
                 <li>• The core idea that situational features systematically generate value tension is
                   very well supported.</li>
-                <li>• Treating these features as a taxonomy of tension carriers is conceptually legitimate
+                <li>• Treating these features as a taxonomy of stressors is conceptually legitimate
                   and empirically defensible.</li>
               </ul>
             </div>
@@ -432,8 +432,8 @@ export default function Research() {
             <div className="p-6 rounded-xl border bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-900">
               <h3 className="font-semibold text-amber-900 dark:text-amber-200 mb-4">What the Research Challenges</h3>
               <ul className="text-sm text-amber-800 dark:text-amber-300 space-y-2">
-                <li>• Fixed, universal effects of any single carrier</li>
-                <li>• Strict independence between carriers</li>
+                <li>• Fixed, universal effects of any single stressor</li>
+                <li>• Strict independence between stressors</li>
                 <li>• Culture-free or role-free interpretations</li>
               </ul>
             </div>
@@ -442,7 +442,7 @@ export default function Research() {
           <div className="p-6 rounded-xl border bg-primary/5 border-primary/20">
             <h3 className="font-semibold mb-4">Best Framing Going Forward</h3>
             <p className="text-muted-foreground">
-              The strongest alignment with the literature is to treat the 12 carriers as:
+              The strongest alignment with the literature is to treat the 12 stressors as:
             </p>
             <blockquote className="mt-4 pl-4 border-l-4 border-primary text-lg font-medium">
               "Recurring situational patterns that probabilistically activate value conflict,
@@ -493,8 +493,8 @@ export default function Research() {
       <footer className="border-t py-8">
         <div className="container text-center text-sm text-muted-foreground">
           <p>
-            <Link to="/carriers" className="text-primary hover:underline">
-              Explore Tension Carriers
+            <Link to="/stressors" className="text-primary hover:underline">
+              Explore Stressors
             </Link>
             {' · '}
             <Link to="/" className="text-primary hover:underline">

--- a/src/pages/Stressors.tsx
+++ b/src/pages/Stressors.tsx
@@ -27,13 +27,13 @@ import {
 } from '@/components/ui/collapsible';
 import { SCHWARTZ_VALUES, HIGHER_ORDER_VALUES, HigherOrderValue, getValueByCode } from '@/lib/schwartz-values';
 import { 
-  CARRIERS, 
-  CARRIER_IDS, 
+  STRESSORS, 
+  STRESSOR_IDS, 
   VALUE_POLARITY_MAP, 
-  findBestCarriersForTension,
-  CarrierId,
+  findBestStressorsForTension,
+  StressorId,
   getPolarity,
-} from '@/lib/carriers';
+} from '@/lib/stressors';
 import { getPolarityExplanation } from '@/lib/polarity-explanations';
 import { ValueAbbreviation } from '@/components/ValueAbbreviation';
 import { cn } from '@/lib/utils';
@@ -53,11 +53,11 @@ function getPolarityTextColor(polarity: number): string {
   return 'text-foreground';
 }
 
-function PolarityCell({ polarity, valueCode, carrierId }: { polarity: number; valueCode: string; carrierId: CarrierId }) {
+function PolarityCell({ polarity, valueCode, stressorId }: { polarity: number; valueCode: string; stressorId: StressorId }) {
   const [open, setOpen] = useState(false);
   const value = getValueByCode(valueCode);
-  const carrier = CARRIERS[carrierId];
-  const explanation = getPolarityExplanation(valueCode, carrierId);
+  const stressor = STRESSORS[stressorId];
+  const explanation = getPolarityExplanation(valueCode, stressorId);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -78,7 +78,7 @@ function PolarityCell({ polarity, valueCode, carrierId }: { polarity: number; va
           <div className="flex items-center justify-between">
             <div>
               <p className="font-semibold">{value?.label ?? valueCode}</p>
-              <p className="text-xs text-muted-foreground">{carrier.name}</p>
+              <p className="text-xs text-muted-foreground">{stressor.name}</p>
             </div>
             <div className={cn(
               'px-2 py-1 rounded text-sm font-bold',
@@ -102,15 +102,15 @@ function PolarityCell({ polarity, valueCode, carrierId }: { polarity: number; va
 function generateTensionExplanation(
   valueCodeA: string,
   valueCodeB: string,
-  carrierId: CarrierId
+  stressorId: StressorId
 ): string {
-  const carrier = CARRIERS[carrierId];
+  const stressor = STRESSORS[stressorId];
   const valueA = getValueByCode(valueCodeA);
   const valueB = getValueByCode(valueCodeB);
-  const polarityA = getPolarity(valueCodeA, carrierId) ?? 0;
-  const polarityB = getPolarity(valueCodeB, carrierId) ?? 0;
-  const explanationA = getPolarityExplanation(valueCodeA, carrierId);
-  const explanationB = getPolarityExplanation(valueCodeB, carrierId);
+  const polarityA = getPolarity(valueCodeA, stressorId) ?? 0;
+  const polarityB = getPolarity(valueCodeB, stressorId) ?? 0;
+  const explanationA = getPolarityExplanation(valueCodeA, stressorId);
+  const explanationB = getPolarityExplanation(valueCodeB, stressorId);
   const diff = Math.abs(polarityA - polarityB);
 
   if (!valueA || !valueB) return '';
@@ -132,34 +132,34 @@ function generateTensionExplanation(
   let explanation = '';
   
   if (diff >= 1.2) {
-    explanation = `This carrier creates **high tension** because the two values respond in opposite ways when ${carrier.name.toLowerCase()} increases.`;
+    explanation = `This stressor creates **high tension** because the two values respond in opposite ways when ${stressor.name.toLowerCase()} increases.`;
   } else if (diff >= 0.7) {
-    explanation = `This carrier creates **moderate tension**. The two values respond differently to changes in ${carrier.name.toLowerCase()}.`;
+    explanation = `This stressor creates **moderate tension**. The two values respond differently to changes in ${stressor.name.toLowerCase()}.`;
   } else {
-    explanation = `This carrier creates **weak tension** because both values respond similarly to ${carrier.name.toLowerCase()}.`;
+    explanation = `This stressor creates **weak tension** because both values respond similarly to ${stressor.name.toLowerCase()}.`;
   }
 
-  explanation += `\n\n**${valueA.label}** (${polarityA > 0 ? '+' : ''}${polarityA.toFixed(1)}): ${explanationA || `Is ${aEffect} when this carrier increases.`}`;
-  explanation += `\n\n**${valueB.label}** (${polarityB > 0 ? '+' : ''}${polarityB.toFixed(1)}): ${explanationB || `Is ${bEffect} when this carrier increases.`}`;
+  explanation += `\n\n**${valueA.label}** (${polarityA > 0 ? '+' : ''}${polarityA.toFixed(1)}): ${explanationA || `Is ${aEffect} when this stressor increases.`}`;
+  explanation += `\n\n**${valueB.label}** (${polarityB > 0 ? '+' : ''}${polarityB.toFixed(1)}): ${explanationB || `Is ${bEffect} when this stressor increases.`}`;
 
   return explanation;
 }
 
 function TensionResult({ 
-  carrierId, 
+  stressorId, 
   polarityDiff,
   valueCodeA,
   valueCodeB,
 }: { 
-  carrierId: CarrierId; 
+  stressorId: StressorId; 
   polarityDiff: number;
   valueCodeA: string;
   valueCodeB: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
-  const carrier = CARRIERS[carrierId];
+  const stressor = STRESSORS[stressorId];
   const absDiff = Math.abs(polarityDiff);
-  const explanation = generateTensionExplanation(valueCodeA, valueCodeB, carrierId);
+  const explanation = generateTensionExplanation(valueCodeA, valueCodeB, stressorId);
   const valueA = getValueByCode(valueCodeA);
   const valueB = getValueByCode(valueCodeB);
 
@@ -176,7 +176,7 @@ function TensionResult({
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <div id={`carrier-${carrierId}`} className="rounded-lg border bg-card overflow-hidden scroll-mt-24">
+      <div id={`stressor-${stressorId}`} className="rounded-lg border bg-card overflow-hidden scroll-mt-24">
         <CollapsibleTrigger className="w-full">
           <div className="flex items-center gap-4 p-4 hover:bg-muted/50 transition-colors">
             <div className={cn(
@@ -189,7 +189,7 @@ function TensionResult({
               {absDiff.toFixed(1)}
             </div>
             <div className="flex-1 text-left">
-              <h4 className="font-semibold">{carrier.name}</h4>
+              <h4 className="font-semibold">{stressor.name}</h4>
             </div>
             <div className="flex items-center gap-3 shrink-0">
               {absDiff >= 1.2 ? (
@@ -228,16 +228,16 @@ function TensionResult({
                 </div>
               </div>
 
-              {/* Link to carrier details */}
+              {/* Link to stressor details */}
               <button 
                 onClick={() => {
-                  const el = document.getElementById(`carrier-list-${carrierId}`);
+                  const el = document.getElementById(`stressor-list-${stressorId}`);
                   if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
                 }}
                 className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
               >
                 <ArrowUp className="w-4 h-4" />
-                View full carrier description & parameters
+                View full stressor description & parameters
               </button>
             </div>
           </div>
@@ -247,7 +247,7 @@ function TensionResult({
   );
 }
 
-export default function Carriers() {
+export default function Stressors() {
   const [selectedValueA, setSelectedValueA] = useState<string>('');
   const [selectedValueB, setSelectedValueB] = useState<string>('');
   
@@ -255,7 +255,7 @@ export default function Carriers() {
     if (!selectedValueA || !selectedValueB || selectedValueA === selectedValueB) {
       return [];
     }
-    return findBestCarriersForTension(selectedValueA, selectedValueB, 12);
+    return findBestStressorsForTension(selectedValueA, selectedValueB, 12);
   }, [selectedValueA, selectedValueB]);
 
   const valuesByQuadrant = useMemo(() => {
@@ -274,7 +274,7 @@ export default function Carriers() {
   return (
     <div className="min-h-screen bg-background">
       <Navigation
-        title="Tension Carriers & Polarity"
+        title="Stressors & Polarity"
         description="Decision-space primitives that expose value tensions"
       />
 
@@ -282,7 +282,7 @@ export default function Carriers() {
       <section className="py-12 border-b">
         <div className="container max-w-4xl">
           <div className="prose prose-gray dark:prose-invert max-w-none">
-            <h2 className="font-serif text-3xl font-bold mb-6">Understanding Tension Carriers</h2>
+            <h2 className="font-serif text-3xl font-bold mb-6">Understanding Stressors</h2>
             
             <div className="grid md:grid-cols-2 gap-6 not-prose mb-8">
               <div className="p-6 rounded-xl border bg-card">
@@ -295,7 +295,7 @@ export default function Carriers() {
               <div className="p-6 rounded-xl border bg-card">
                 <h3 className="font-serif text-lg font-semibold mb-2 text-primary">Decision Space</h3>
                 <p className="text-muted-foreground">
-                  <strong>Carriers</strong> are forms of scarcity or constraint that force tradeoffs. 
+                  <strong>Stressors</strong> are forms of scarcity or constraint that force tradeoffs. 
                   They make latent value differences behaviorally visible.
                 </p>
               </div>
@@ -305,10 +305,10 @@ export default function Carriers() {
               <div className="flex gap-3">
                 <Info className="w-5 h-5 text-primary shrink-0 mt-0.5" />
                 <div>
-                  <p className="font-medium mb-2">Why Carriers Matter</p>
+                  <p className="font-medium mb-2">Why Stressors Matter</p>
                   <p className="text-sm text-muted-foreground">
-                    Without a relevant carrier, two people with very different values may behave identically —
-                    no scarcity means no forced choice. Carriers are the "pressure" that reveals what people truly prioritize.
+                    Without a relevant stressor, two people with very different values may behave identically —
+                    no scarcity means no forced choice. Stressors are the "pressure" that reveals what people truly prioritize.
                   </p>
                 </div>
               </div>
@@ -323,8 +323,8 @@ export default function Carriers() {
                     Research supports that situational features systematically generate value tension. However:
                   </p>
                   <ul className="text-sm text-amber-800 dark:text-amber-300 space-y-1 mb-3">
-                    <li>• Carrier effects are <strong>probabilistic, not deterministic</strong> — individual differences in identity, experience, and coping resources moderate their impact</li>
-                    <li>• The 12 carriers are <strong>analytical lenses, not independent variables</strong> — in practice, they overlap and correlate</li>
+                    <li>• Stressor effects are <strong>probabilistic, not deterministic</strong> — individual differences in identity, experience, and coping resources moderate their impact</li>
+                    <li>• The 12 stressors are <strong>analytical lenses, not independent variables</strong> — in practice, they overlap and correlate</li>
                     <li>• Effects are <strong>culturally and institutionally mediated</strong> — authority and autonomy tensions differ across contexts (healthcare vs. military vs. startups)</li>
                   </ul>
                   <Link to="/research" className="text-sm text-amber-700 dark:text-amber-400 hover:underline font-medium">
@@ -337,25 +337,25 @@ export default function Carriers() {
         </div>
       </section>
 
-      {/* The 12 Carriers */}
+      {/* The 12 Stressors */}
       <section className="py-12 border-b bg-muted/30">
         <div className="container">
-          <h2 className="font-serif text-3xl font-bold mb-8">The 12 Carriers</h2>
+          <h2 className="font-serif text-3xl font-bold mb-8">The 12 Stressors</h2>
           
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {CARRIER_IDS.map(id => {
-              const carrier = CARRIERS[id];
+            {STRESSOR_IDS.map(id => {
+              const stressor = STRESSORS[id];
               return (
-                <div key={id} id={`carrier-list-${id}`} className="p-5 rounded-xl border bg-card scroll-mt-24">
-                  <h3 className="font-serif text-lg font-semibold mb-2">{carrier.name}</h3>
-                  <p className="text-sm text-muted-foreground mb-3">{carrier.description}</p>
+                <div key={id} id={`stressor-list-${id}`} className="p-5 rounded-xl border bg-card scroll-mt-24">
+                  <h3 className="font-serif text-lg font-semibold mb-2">{stressor.name}</h3>
+                  <p className="text-sm text-muted-foreground mb-3">{stressor.description}</p>
                   <div className="p-3 rounded-lg bg-muted/50 border border-dashed mb-4">
                     <p className="text-xs text-muted-foreground italic">
-                      <span className="font-medium not-italic">Example:</span> {carrier.example}
+                      <span className="font-medium not-italic">Example:</span> {stressor.example}
                     </p>
                   </div>
                   <div className="space-y-2">
-                    {carrier.parameters.map(param => (
+                    {stressor.parameters.map(param => (
                       <div key={param.id} className="flex items-center justify-between text-xs">
                         <span className="text-muted-foreground">{param.lowLabel}</span>
                         <span className="px-2 py-0.5 rounded bg-muted font-medium">{param.name}</span>
@@ -375,7 +375,7 @@ export default function Carriers() {
         <div className="container">
           <h2 className="font-serif text-3xl font-bold mb-4">Polarity Heatmap</h2>
           <p className="text-muted-foreground mb-8 max-w-2xl">
-            Each cell shows how increasing a carrier's intensity tends to <span className="text-emerald-600 font-medium">satisfy (+)</span> or{' '}
+            Each cell shows how increasing a stressor's intensity tends to <span className="text-emerald-600 font-medium">satisfy (+)</span> or{' '}
             <span className="text-rose-600 font-medium">frustrate (-)</span> a value.
           </p>
 
@@ -386,17 +386,17 @@ export default function Carriers() {
                   <th className="text-left p-2 text-sm font-medium text-muted-foreground sticky left-0 bg-background z-10">
                     Value
                   </th>
-                  {CARRIER_IDS.map(id => (
+                  {STRESSOR_IDS.map(id => (
                     <th key={id} className="p-2 text-center">
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span className="text-xs font-medium text-muted-foreground cursor-help whitespace-nowrap">
-                            {CARRIERS[id].name.split(' / ')[0]}
+                            {STRESSORS[id].name.split(' / ')[0]}
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top" className="max-w-xs">
-                          <p className="font-semibold">{CARRIERS[id].name}</p>
-                          <p className="text-xs text-muted-foreground">{CARRIERS[id].description}</p>
+                          <p className="font-semibold">{STRESSORS[id].name}</p>
+                          <p className="text-xs text-muted-foreground">{STRESSORS[id].description}</p>
                         </TooltipContent>
                       </Tooltip>
                     </th>
@@ -408,7 +408,7 @@ export default function Carriers() {
                   <>
                     <tr key={`header-${quadrant}`}>
                       <td 
-                        colSpan={CARRIER_IDS.length + 1} 
+                        colSpan={STRESSOR_IDS.length + 1} 
                         className="pt-6 pb-2 px-2 text-sm font-semibold"
                         style={{ color: `hsl(var(--${HIGHER_ORDER_VALUES[quadrant].color}))` }}
                       >
@@ -420,11 +420,11 @@ export default function Carriers() {
                         <td className="p-2 sticky left-0 bg-background z-10">
                           <ValueAbbreviation code={value.code} className="text-sm" />
                         </td>
-                        {CARRIER_IDS.map(carrierId => {
-                          const polarity = VALUE_POLARITY_MAP[value.code]?.[carrierId] ?? 0;
+                        {STRESSOR_IDS.map(stressorId => {
+                          const polarity = VALUE_POLARITY_MAP[value.code]?.[stressorId] ?? 0;
                           return (
-                            <td key={carrierId} className="p-1">
-                              <PolarityCell polarity={polarity} valueCode={value.code} carrierId={carrierId} />
+                            <td key={stressorId} className="p-1">
+                              <PolarityCell polarity={polarity} valueCode={value.code} stressorId={stressorId} />
                             </td>
                           );
                         })}
@@ -468,7 +468,7 @@ export default function Carriers() {
         <div className="container max-w-4xl">
           <h2 className="font-serif text-3xl font-bold mb-4">Tension Analyzer</h2>
           <p className="text-muted-foreground mb-8">
-            Select two values to see which carriers will most strongly expose the tension between them.
+            Select two values to see which stressors will most strongly expose the tension between them.
           </p>
 
           <div className="grid md:grid-cols-2 gap-4 mb-8">
@@ -530,12 +530,12 @@ export default function Carriers() {
           {selectedValueA && selectedValueB && selectedValueA !== selectedValueB && (
             <div className="space-y-3">
               <h3 className="font-serif text-xl font-semibold mb-4">
-                Carriers ranked by tension exposure
+                Stressors ranked by tension exposure
               </h3>
               {tensionResults.map(result => (
                 <TensionResult 
-                  key={result.carrier.id} 
-                  carrierId={result.carrier.id} 
+                  key={result.stressor.id} 
+                  stressorId={result.stressor.id} 
                   polarityDiff={result.polarityDiff}
                   valueCodeA={selectedValueA}
                   valueCodeB={selectedValueB}
@@ -547,7 +547,7 @@ export default function Carriers() {
           {(!selectedValueA || !selectedValueB) && (
             <div className="text-center py-12 text-muted-foreground">
               <Info className="w-12 h-12 mx-auto mb-4 opacity-50" />
-              <p>Select two values above to analyze which carriers expose their tension.</p>
+              <p>Select two values above to analyze which stressors expose their tension.</p>
             </div>
           )}
         </div>
@@ -570,7 +570,7 @@ export default function Carriers() {
           </p>
           <p className="mt-2">
             <Link to="/research" className="text-primary hover:underline">
-              Research background for the tension carriers framework
+              Research background for the stressors framework
             </Link>
           </p>
         </div>

--- a/supabase/functions/generate-clarification-scenarios/index.ts
+++ b/supabase/functions/generate-clarification-scenarios/index.ts
@@ -5,10 +5,10 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 };
 
-interface CarrierData {
-  carrierId: string;
-  carrierName: string;
-  carrierDescription: string;
+interface StressorData {
+  stressorId: string;
+  stressorName: string;
+  stressorDescription: string;
   highPolarityValues: Array<{ code: string; label: string; polarity: number }>;
   lowPolarityValues: Array<{ code: string; label: string; polarity: number }>;
 }
@@ -16,7 +16,7 @@ interface CarrierData {
 interface RequestBody {
   jobDescription: string;
   jobTitle?: string;
-  carriers: CarrierData[];
+  stressors: StressorData[];
 }
 
 serve(async (req) => {
@@ -25,7 +25,7 @@ serve(async (req) => {
   }
 
   try {
-    const { jobDescription, jobTitle, carriers } = await req.json() as RequestBody;
+    const { jobDescription, jobTitle, stressors } = await req.json() as RequestBody;
 
     if (!jobDescription || jobDescription.length < 50) {
       return new Response(
@@ -34,9 +34,9 @@ serve(async (req) => {
       );
     }
 
-    if (!carriers || carriers.length === 0) {
+    if (!stressors || stressors.length === 0) {
       return new Response(
-        JSON.stringify({ error: "At least one carrier must be provided" }),
+        JSON.stringify({ error: "At least one stressor must be provided" }),
         { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
       );
     }
@@ -46,16 +46,16 @@ serve(async (req) => {
       throw new Error("OPENAI_API_KEY is not configured");
     }
 
-    // Build carrier descriptions for the prompt
-    const carrierPrompts = carriers.map(c => {
+    // Build stressor descriptions for the prompt
+    const stressorPrompts = stressors.map(c => {
       const highValues = c.highPolarityValues.map(v => `${v.label} (${v.code})`).join(", ");
       const lowValues = c.lowPolarityValues.map(v => `${v.label} (${v.code})`).join(", ");
 
       return `
-CARRIER: ${c.carrierName}
-Description: ${c.carrierDescription}
-Values favored by HIGH ${c.carrierName}: ${highValues || "none strongly"}
-Values favored by LOW ${c.carrierName}: ${lowValues || "none strongly"}`;
+STRESSOR: ${c.stressorName}
+Description: ${c.stressorDescription}
+Values favored by HIGH ${c.stressorName}: ${highValues || "none strongly"}
+Values favored by LOW ${c.stressorName}: ${lowValues || "none strongly"}`;
     }).join("\n\n");
 
     const systemPrompt = `You are an expert in organizational psychology and Schwartz's Theory of Basic Human Values.
@@ -67,8 +67,8 @@ For each scenario:
 2. Frame it as a question to ask the hiring manager about what they would prefer
 3. Present two behavioral options (A and B) that authentically represent different value priorities
 4. Make both options reasonable - neither should be obviously "wrong"
-5. Option A should favor values with HIGH polarity on the given carrier dimension
-6. Option B should favor values with LOW polarity on the given carrier dimension
+5. Option A should favor values with HIGH polarity on the given stressor dimension
+6. Option B should favor values with LOW polarity on the given stressor dimension
 7. Keep scenarios concise (2-3 sentences for setup ending with "Would you prefer them to...", 1 sentence per option)
 
 IMPORTANT: Frame scenarios in THIRD PERSON as questions about "the person in this role" - NOT in second person ("you"). These are questions for candidates to ask hiring managers.
@@ -94,15 +94,15 @@ ${jobTitle ? `JOB TITLE: ${jobTitle}\n` : ""}
 JOB DESCRIPTION:
 ${jobDescription}
 
-Generate ONE scenario/question for EACH of these carriers:
-${carrierPrompts}
+Generate ONE scenario/question for EACH of these stressors:
+${stressorPrompts}
 
 Return JSON in this exact format:
 {
   "scenarios": [
     {
-      "carrierId": "the_carrier_id",
-      "carrierName": "Carrier Name",
+      "stressorId": "the_stressor_id",
+      "stressorName": "Stressor Name",
       "setup": "Imagine [specific situation from the job], leaving the person in this role [context]. Would you prefer them to...",
       "optionA": "[Specific action favoring high-polarity values, starting with a verb]",
       "optionB": "[Specific action favoring low-polarity values, starting with a verb]",
@@ -112,7 +112,7 @@ Return JSON in this exact format:
   ]
 }`;
 
-    console.log("Generating clarification scenarios for", carriers.length, "carriers");
+    console.log("Generating clarification scenarios for", stressors.length, "stressors");
 
     const response = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",

--- a/supabase/functions/generate-persona-scenario/index.ts
+++ b/supabase/functions/generate-persona-scenario/index.ts
@@ -11,7 +11,7 @@ interface PersonaData {
   valueProfile: Record<string, number>;
 }
 
-interface CarrierData {
+interface StressorData {
   id: string;
   name: string;
   description: string;
@@ -20,7 +20,7 @@ interface CarrierData {
 interface TensionData {
   valueA: string;
   valueB: string;
-  carrier: string;
+  stressor: string;
   explanation: string;
 }
 
@@ -30,9 +30,9 @@ serve(async (req) => {
   }
 
   try {
-    const { personas, carriers, tensions } = await req.json() as { 
+    const { personas, stressors, tensions } = await req.json() as { 
       personas: PersonaData[]; 
-      carriers: CarrierData[];
+      stressors: StressorData[];
       tensions: TensionData[];
     };
     
@@ -43,9 +43,9 @@ serve(async (req) => {
       );
     }
 
-    if (!carriers || carriers.length === 0) {
+    if (!stressors || stressors.length === 0) {
       return new Response(
-        JSON.stringify({ error: "At least 1 carrier must be selected" }),
+        JSON.stringify({ error: "At least 1 stressor must be selected" }),
         { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
       );
     }
@@ -71,10 +71,10 @@ serve(async (req) => {
 - Avoided/opposed: ${lowValues || 'none strongly opposed'}`;
     }).join('\n\n');
 
-    const carrierList = carriers.map(c => `- **${c.name}**: ${c.description}`).join('\n');
+    const stressorList = stressors.map(c => `- **${c.name}**: ${c.description}`).join('\n');
     
     const tensionList = tensions.map(t => 
-      `- ${t.valueA} vs ${t.valueB} (via ${t.carrier}): ${t.explanation}`
+      `- ${t.valueA} vs ${t.valueB} (via ${t.stressor}): ${t.explanation}`
     ).join('\n');
 
     const systemPrompt = `You are a dramatist and expert in Schwartz's Theory of Basic Human Values.
@@ -95,8 +95,8 @@ Write in a vivid, psychologically insightful style. Make each perspective authen
 
 ${personaSummaries}
 
-And these environmental conditions/carriers that will shape their interaction:
-${carrierList}
+And these environmental conditions/stressors that will shape their interaction:
+${stressorList}
 
 Key value tensions that will emerge:
 ${tensionList}
@@ -104,7 +104,7 @@ ${tensionList}
 Generate a rich scenario analysis with these three sections:
 
 ## SCENARIO SETUP
-(2-3 paragraphs) Describe a specific, concrete situation where these personas must interact while experiencing these carriers/conditions. Make it vivid and realistic - where are they, what's at stake, what decision or action has brought them into conflict?
+(2-3 paragraphs) Describe a specific, concrete situation where these personas must interact while experiencing these stressors/conditions. Make it vivid and realistic - where are they, what's at stake, what decision or action has brought them into conflict?
 
 ## THIRD-PARTY OBSERVATION
 (3-4 paragraphs) Write as an objective observer watching this conflict unfold. Describe what you see happening between these two personas. Note the subtext, the body language, the escalation or de-escalation patterns. Identify what each person seems to want and why they're clashing. Be insightful about the value dynamics at play.
@@ -118,7 +118,7 @@ Generate a rich scenario analysis with these three sections:
 Make each perspective genuinely reflect that persona's value system. Show how the same events look completely different through different value lenses.`;
 
     console.log("Generating persona scenario for:", personas.map(p => p.name).join(" vs "));
-    console.log("Carriers:", carriers.map(c => c.name).join(", "));
+    console.log("Stressors:", stressors.map(c => c.name).join(", "));
 
     const response = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",


### PR DESCRIPTION
Replaces all uses of "carrier" / "Carrier" / "tension carrier" with
"stressor" / "Stressor" across UI text, type names, function names,
variable names, file names, and edge functions.

- 5 files renamed (carriers.ts, carrier-sensitivity.ts, Carriers.tsx,
  CarrierSensitivityPanel.tsx, ProfileTensionCarriers.tsx)
- Route /carriers → /stressors
- Types: CarrierId → StressorId, Carrier → Stressor, CARRIERS → STRESSORS
- All UI labels, headings, and nav links updated

The 12 stressor IDs in the DB (e.g. risk_uncertainty) are unchanged.

https://claude.ai/code/session_01CDqQsttS9VULM2H2WUq5P7