### PR TITLE
docs: sync CLAUDE.md and README with actual codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ values-explorer/
 │   │   ├── Navigation.tsx         # Top nav dropdown
 │   │   ├── ValueAbbreviation.tsx  # Renders 3-letter value codes
 │   │   ├── ValueEditor.tsx        # Individual value slider
+│   │   ├── NavLink.tsx            # React Router NavLink wrapper with className/activeClassName support
 │   │   └── InfoPopover.tsx        # ⓘ info icon + popover (mobile-safe; use instead of Tooltip)
 │   ├── pages/
 │   │   ├── Landing.tsx            # Home: archetype browser + saved profiles
@@ -95,6 +96,7 @@ values-explorer/
 │   │   ├── DataExport.tsx         # Export profiles as JSON
 │   │   ├── Research.tsx           # Literature review background
 │   │   ├── SharedProfile.tsx      # Public profile view (/p/:id)
+│   │   ├── PreferredVerbs.tsx     # Value-driven verb phrases per archetype
 │   │   └── NotFound.tsx           # 404
 │   ├── lib/
 │   │   ├── schwartz-values.ts     # 19 PVQ-RR value definitions + helpers
@@ -150,6 +152,7 @@ Defined in `src/App.tsx`:
 | `/export` | `DataExport` | Export profiles as JSON |
 | `/research` | `Research` | Academic background |
 | `/p/:id` | `SharedProfile` | Publicly shared profile |
+| `/preferred-verbs` | `PreferredVerbs` | Value-driven verb phrases for archetypes |
 
 **Router selection:** `HashRouter` on `brtrx.github.io` (GitHub Pages), `BrowserRouter` elsewhere. The base path is `/values-explorer/` when built via GitHub Actions.
 
@@ -187,7 +190,7 @@ Default score: `3.5` (midpoint of 1–6 range). Source in `src/lib/schwartz-valu
 
 ### Archetypes
 
-90+ predefined profiles in `src/lib/archetypes.ts`. Each archetype has relative value weightings (−3 to +3 delta). Categories: fictional characters, historical figures, superheroes, mythological, literary, cultural roles.
+81 predefined profiles in `src/lib/archetypes.ts`. Each archetype has relative value weightings (−3 to +3 delta). Categories: fictional characters, historical figures, superheroes, mythological, literary, cultural roles.
 
 Inter-page state: `sessionStorage.loadArchetype` passes an archetype to the editor.
 
@@ -308,7 +311,7 @@ When working on Claude-assisted tasks, develop on the designated branch and push
 |---|---|
 | `src/App.tsx` | All routes defined here |
 | `src/lib/schwartz-values.ts` | Canonical value definitions and helpers |
-| `src/lib/archetypes.ts` | All 90+ archetype profiles |
+| `src/lib/archetypes.ts` | All 81 archetype profiles |
 | `src/lib/stressors.ts` | Stressor framework and polarity vectors |
 | `src/lib/profile-storage.ts` | All Supabase DB operations |
 | `src/integrations/supabase/client.ts` | Supabase client (singleton) |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An interactive philosophical tool for exploring Schwartz's Theory of Basic Human
 
 - **Value Profile Editor**: Create and customize profiles using the 19 Schwartz PVQ-RR values
 - **Schwartz Circumplex Visualization**: Interactive circular display of value relationships
-- **Archetype Library**: 80+ pre-built character profiles (historical figures, fictional characters, mythological beings)
+- **Archetype Library**: 81 pre-built character profiles (historical figures, fictional characters, mythological beings)
 - **Profile Comparison**: Compare multiple profiles to identify value alignments and tensions
 - **Stressor Analysis**: Explore 12 decision-space dimensions that place stress on value preferences, forcing trade-offs
 - **AI Scenario Generation**: Generate narratives that reveal how value tensions play out
@@ -50,10 +50,10 @@ The app will be available at http://localhost:8080
 
 ## Environment Variables
 
-Create a `.env` file based on `.env.example`:
+Create a `.env.local` file based on `.env.example`:
 
 ```bash
-cp .env.example .env
+cp .env.example .env.local
 ```
 
 Required variables:
@@ -62,7 +62,7 @@ Required variables:
 |----------|-------------|----------|
 | `VITE_SUPABASE_URL` | Your Supabase project URL | Yes |
 | `VITE_SUPABASE_PUBLISHABLE_KEY` | Supabase anon/public key | Yes |
-| `OPENAI_API_KEY` | OpenAI API key for AI features | Yes (for Edge Functions) |
+| `OPENAI_API_KEY` | OpenAI API key for AI features | Yes (Supabase secret only — never in `.env`) |
 
 The `OPENAI_API_KEY` must be set as a Supabase secret for the Edge Functions:
 


### PR DESCRIPTION
- Fix archetype count (90+/80+ → 81 actual profiles)
- Add missing NavLink.tsx component entry to CLAUDE.md
- Add missing PreferredVerbs.tsx page and /preferred-verbs route to CLAUDE.md
- Fix README env file name (.env → .env.local) and OPENAI_API_KEY note

https://claude.ai/code/session_0131WfarcWGfnNUfdKXCs5xG