### PR TITLE
Fix double-slash URL bug in Edge Function fetch calls

### DIFF
--- a/src/components/ClarificationPanel.tsx
+++ b/src/components/ClarificationPanel.tsx
@@ -16,7 +16,8 @@ import {
 import { StressorId } from '@/lib/stressors';
 import { toast } from 'sonner';
 
-const CLARIFICATION_URL = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-clarification-scenarios`;
+const SUPABASE_BASE_URL = (import.meta.env.VITE_SUPABASE_URL as string).replace(/\/$/, '');
+const CLARIFICATION_URL = `${SUPABASE_BASE_URL}/functions/v1/generate-clarification-scenarios`;
 
 interface Scenario {
   stressorId: string;

--- a/src/components/ConflictScenario.tsx
+++ b/src/components/ConflictScenario.tsx
@@ -16,8 +16,9 @@ import { analyzeReconciliation } from '@/lib/reconciliation-analysis';
 import { buildConflictPrompt, buildReconciliationPrompt, PromptPair } from '@/lib/prompt-builders';
 import { stripMarkdown } from '@/lib/utils';
 
-const CONFLICT_URL = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-conflict-scenario`;
-const RECONCILIATION_URL = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-reconciliation`;
+const SUPABASE_BASE_URL = (import.meta.env.VITE_SUPABASE_URL as string).replace(/\/$/, '');
+const CONFLICT_URL = `${SUPABASE_BASE_URL}/functions/v1/generate-conflict-scenario`;
+const RECONCILIATION_URL = `${SUPABASE_BASE_URL}/functions/v1/generate-reconciliation`;
 
 interface CustomProfile {
   name: string;

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -15,7 +15,8 @@ import { buildComparisonPrompt, PromptPair } from '@/lib/prompt-builders';
 import { stripMarkdown } from '@/lib/utils';
 import { toast } from 'sonner';
 
-const COMPARE_URL = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/compare-archetypes`;
+const SUPABASE_BASE_URL = (import.meta.env.VITE_SUPABASE_URL as string).replace(/\/$/, '');
+const COMPARE_URL = `${SUPABASE_BASE_URL}/functions/v1/compare-archetypes`;
 
 // Custom profile type for user-created profiles
 interface CustomProfile {

--- a/src/pages/ExploreScenarios.tsx
+++ b/src/pages/ExploreScenarios.tsx
@@ -12,7 +12,8 @@ import { OverlappingSchwartzCircle } from '@/components/OverlappingSchwartzCircl
 import { ValueAbbreviation } from '@/components/ValueAbbreviation';
 import { toast } from 'sonner';
 
-const SCENARIO_URL = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-persona-scenario`;
+const SUPABASE_BASE_URL = (import.meta.env.VITE_SUPABASE_URL as string).replace(/\/$/, '');
+const SCENARIO_URL = `${SUPABASE_BASE_URL}/functions/v1/generate-persona-scenario`;
 
 // Predefined colors for the two personas
 const PERSONA_COLORS = ['#3b82f6', '#ef4444'];
@@ -226,7 +227,10 @@ export default function ExploreScenarios() {
 
       const response = await fetch(SCENARIO_URL, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY}`,
+        },
         body: JSON.stringify({
           personas: personaData.map(p => ({
             name: p.name,


### PR DESCRIPTION
VITE_SUPABASE_URL in .env.local had a trailing slash, causing all manually-constructed Edge Function URLs to contain a double slash (e.g. ...supabase.co//functions/v1/...). Cloudflare rejects double-slash paths at the connection level, producing ERR_INTERNET_DISCONNECTED in Chrome instead of a normal HTTP error.

Fixes:
- Strip trailing slash from VITE_SUPABASE_URL before building URLs in ClarificationPanel, ConflictScenario, ExploreScenarios, Compare
- Add missing Authorization header in ExploreScenarios fetch call (generate-persona-scenario was called without auth, causing 401s)

JobAnalysis.tsx was already correct as it uses supabase.functions.invoke() which handles URL construction internally.

https://claude.ai/code/session_01Dj5fCarqQ4gGCUMVJ2HZ7o