### PR TITLE
Add feature flag system; disable Job Analysis by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Defined in `src/App.tsx`:
 | `/compare` | `Compare` | Compare multiple profiles |
 | `/stressors` | `Stressors` | Explore stressors |
 | `/scenarios` | `ExploreScenarios` | AI scenario generation |
-| `/job-analysis` | `JobAnalysis` | Analyze job descriptions |
+| `/job-analysis` | `JobAnalysis` | Analyze job descriptions *(feature-flagged off — set `FEATURES.jobAnalysis = true` in `src/lib/features.ts` to re-enable)* |
 | `/export` | `DataExport` | Export profiles as JSON |
 | `/research` | `Research` | Academic background |
 | `/p/:id` | `SharedProfile` | Publicly shared profile |
@@ -310,6 +310,7 @@ When working on Claude-assisted tasks, develop on the designated branch and push
 | File | Why it matters |
 |---|---|
 | `src/App.tsx` | All routes defined here |
+| `src/lib/features.ts` | Feature flags — toggle pages/features on/off by flipping booleans |
 | `src/lib/schwartz-values.ts` | Canonical value definitions and helpers |
 | `src/lib/archetypes.ts` | All 81 archetype profiles |
 | `src/lib/stressors.ts` | Stressor framework and polarity vectors |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import JobAnalysis from "./pages/JobAnalysis";
 import Research from "./pages/Research";
 import PreferredVerbs from "./pages/PreferredVerbs";
 import NotFound from "./pages/NotFound";
+import { FEATURES } from "@/lib/features";
 
 const queryClient = new QueryClient();
 
@@ -37,7 +38,7 @@ const App = () => {
             <Route path="/scenarios" element={<ExploreScenarios />} />
             <Route path="/p/:id" element={<SharedProfile />} />
             <Route path="/export" element={<DataExport />} />
-            <Route path="/job-analysis" element={<JobAnalysis />} />
+            {FEATURES.jobAnalysis && <Route path="/job-analysis" element={<JobAnalysis />} />}
             <Route path="/research" element={<Research />} />
             <Route path="/preferred-verbs" element={<PreferredVerbs />} />
             <Route path="*" element={<NotFound />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,12 +8,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { FEATURES } from '@/lib/features';
 
 interface NavItem {
   to: string;
   label: string;
   description?: string;
   icon: React.ComponentType<{ className?: string }>;
+  hidden?: boolean;
 }
 
 const NAV_ITEMS: NavItem[] = [
@@ -22,11 +24,13 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/compare', label: 'Compare Profiles', description: 'Compare two profiles side-by-side', icon: Users },
   { to: '/stressors', label: 'Stressors', description: 'Explore value polarities', icon: Layers },
   { to: '/scenarios', label: 'Explore Scenarios', description: 'AI-generated conflict scenarios', icon: Sparkles },
-  { to: '/job-analysis', label: 'Job Analysis', description: 'Analyze job descriptions', icon: Briefcase },
+  { to: '/job-analysis', label: 'Job Analysis', description: 'Analyze job descriptions', icon: Briefcase, hidden: !FEATURES.jobAnalysis },
   { to: '/export', label: 'Data Export', description: 'Export profiles as JSON', icon: FileDown },
   { to: '/preferred-verbs', label: 'Preferred Verbs', description: 'Values as first-person verb forms', icon: Languages },
   { to: '/research', label: 'Research Background', description: 'Literature review', icon: BookOpen },
 ];
+
+const VISIBLE_NAV_ITEMS = NAV_ITEMS.filter(item => !item.hidden);
 
 interface NavigationProps {
   title: string;
@@ -49,14 +53,14 @@ export function Navigation({ title, description }: NavigationProps) {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="w-64">
-            {NAV_ITEMS.map((item, index) => {
+            {VISIBLE_NAV_ITEMS.map((item, index) => {
               const Icon = item.icon;
               const isActive = currentPath === item.to;
 
               return (
                 <div key={item.to}>
                   {index === 1 && <DropdownMenuSeparator />}
-                  {index === NAV_ITEMS.length - 1 && <DropdownMenuSeparator />}
+                  {index === VISIBLE_NAV_ITEMS.length - 1 && <DropdownMenuSeparator />}
                   <DropdownMenuItem
                     disabled={isActive}
                     onSelect={() => navigate(item.to)}

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,0 +1,9 @@
+/**
+ * Feature flags — flip a value here to enable or disable a feature across
+ * the app (navigation + routes).  No deploy config required; just change
+ * the boolean and push.
+ */
+export const FEATURES = {
+  /** Set to true to re-enable the Job Analysis page (/job-analysis). */
+  jobAnalysis: false,
+} as const;


### PR DESCRIPTION
## Summary

Introduces a feature flag system to allow toggling features on/off without deploy configuration. The Job Analysis page is now feature-flagged off by default and can be re-enabled by setting `FEATURES.jobAnalysis = true` in `src/lib/features.ts`.

## Changes

- **New file: `src/lib/features.ts`** — Centralized feature flag configuration with `FEATURES.jobAnalysis` (currently `false`)
- **`src/App.tsx`** — Conditionally render the `/job-analysis` route only when `FEATURES.jobAnalysis` is enabled
- **`src/components/Navigation.tsx`** — Added `hidden` property to `NavItem` interface; filter navigation items to exclude hidden ones; updated dropdown menu rendering to use filtered list
- **`CLAUDE.md`** — Updated routing table to note that Job Analysis is feature-flagged off; added `src/lib/features.ts` to the key files reference

## Implementation Details

- The `NavItem` interface now includes an optional `hidden` boolean property
- Navigation items are filtered at definition time via `VISIBLE_NAV_ITEMS` constant
- Dropdown menu separators are positioned based on the filtered list length, not the original list
- Feature flags are exported as a `const` object for type safety and IDE autocomplete support
- No route is registered when the feature is disabled, preventing accidental access via direct URL navigation

https://claude.ai/code/session_01G6ojTaAc1pCg3gjWmXCFHV