### PR TITLE
Feature-flag off Data Export page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ const App = () => {
             <Route path="/stressors" element={<Stressors />} />
             <Route path="/scenarios" element={<ExploreScenarios />} />
             <Route path="/p/:id" element={<SharedProfile />} />
-            <Route path="/export" element={<DataExport />} />
+            {FEATURES.dataExport && <Route path="/export" element={<DataExport />} />}
             {FEATURES.jobAnalysis && <Route path="/job-analysis" element={<JobAnalysis />} />}
             <Route path="/research" element={<Research />} />
             <Route path="/preferred-verbs" element={<PreferredVerbs />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -25,7 +25,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/stressors', label: 'Stressors', description: 'Explore value polarities', icon: Layers },
   { to: '/scenarios', label: 'Explore Scenarios', description: 'AI-generated conflict scenarios', icon: Sparkles },
   { to: '/job-analysis', label: 'Job Analysis', description: 'Analyze job descriptions', icon: Briefcase, hidden: !FEATURES.jobAnalysis },
-  { to: '/export', label: 'Data Export', description: 'Export profiles as JSON', icon: FileDown },
+  { to: '/export', label: 'Data Export', description: 'Export profiles as JSON', icon: FileDown, hidden: !FEATURES.dataExport },
   { to: '/preferred-verbs', label: 'Preferred Verbs', description: 'Values as first-person verb forms', icon: Languages },
   { to: '/research', label: 'Research Background', description: 'Literature review', icon: BookOpen },
 ];

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -6,4 +6,6 @@
 export const FEATURES = {
   /** Set to true to re-enable the Job Analysis page (/job-analysis). */
   jobAnalysis: false,
+  /** Set to true to re-enable the Data Export page (/export). */
+  dataExport: false,
 } as const;


### PR DESCRIPTION
Set FEATURES.dataExport = false — hides nav item and disables /export route. Flip to true in src/lib/features.ts to restore.

https://claude.ai/code/session_01G6ojTaAc1pCg3gjWmXCFHV